### PR TITLE
Use regional storage for pubsub topics

### DIFF
--- a/cloudevent-broker/main.tf
+++ b/cloudevent-broker/main.tf
@@ -12,4 +12,8 @@ resource "google_pubsub_topic" "this" {
 
   // TODO: Tune this and/or make it configurable?
   message_retention_duration = "600s"
+
+  message_storage_policy {
+    allowed_persistence_regions = [each.key]
+  }
 }


### PR DESCRIPTION
This should insulate each region's event delivery pipeline from outages affecting other regions.

Fixes: https://github.com/chainguard-dev/terraform-infra-common/issues/53