### PR TITLE
Fix the name of the regional environment variable.

### DIFF
--- a/cloudevent-broker/README.md
+++ b/cloudevent-broker/README.md
@@ -55,7 +55,7 @@ module "foo-service" {
       }
       ports = [{ container_port = 8080 }]
       regional-env = [{
-        name  = "PUBSUB_TOPIC"
+        name  = "EVENT_INGRESS_URI"
         value = { for k, v in module.foo-emits-events : k => v.uri }
       }]
     }


### PR DESCRIPTION
I noticed that the name of the regional environment variable was `PUBSUB_TOPIC` but we pass in the regional service's URI, so renaming it.