### PR TITLE
Migrate several `_iam_member` to `_iam_binding` rules.

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -70,14 +70,14 @@ No requirements.
 | [google_bigquery_data_transfer_config.import-job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_data_transfer_config) | resource |
 | [google_bigquery_dataset.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
 | [google_bigquery_table.types](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) | resource |
-| [google_bigquery_table_iam_member.import-writes-to-tables](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_member) | resource |
+| [google_bigquery_table_iam_binding.import-writes-to-tables](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_binding) | resource |
 | [google_service_account.import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.recorder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_member.bq-dts-assumes-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.provisioner-acts-as-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_binding.bq-dts-assumes-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.provisioner-acts-as-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_storage_bucket.recorder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
-| [google_storage_bucket_iam_member.import-reads-from-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
-| [google_storage_bucket_iam_member.recorder-writes-to-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_iam_binding.import-reads-from-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
+| [google_storage_bucket_iam_binding.recorder-writes-to-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.trigger-suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -7,13 +7,14 @@ resource "google_service_account" "recorder" {
   description  = "Dedicated service account for our recorder service."
 }
 
-// Grant the recorder service account permission to write to the regional GCS buckets.
-resource "google_storage_bucket_iam_member" "recorder-writes-to-gcs-buckets" {
+// The recorder service account is the only identity that should be writing
+// to the regional GCS buckets.
+resource "google_storage_bucket_iam_binding" "recorder-writes-to-gcs-buckets" {
   for_each = var.regions
 
-  bucket = google_storage_bucket.recorder[each.key].name
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.recorder.email}"
+  bucket  = google_storage_bucket.recorder[each.key].name
+  role    = "roles/storage.admin"
+  members = ["serviceAccount:${google_service_account.recorder.email}"]
 }
 
 module "this" {


### PR DESCRIPTION
Generally I have trained myself to use `_iam_member` because of the likelihood for `binding` to stomp on each other, but in the case of certain resources `binding` is the most appropriate resource to use.

From some internal docs I'm working on:
```
> Guidance: when the resource in question is an implementation detail of
> the module, then the module should leverage `binding` to grant its identities
> exclusive access to interact with the resource.  But when a resource is shared
> and a module is one consumer with incomplete knowledge of the ACL membership
> then it should use the `member` form.
```