### PR TITLE
networking: Allow configurable netnum offsets.

### DIFF
--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -8,5 +8,6 @@ for d in `find . -name '*.tf' -exec dirname {} \; | sort | uniq`; do
     terraform-docs markdown table \
         --output-file README.md \
         --output-mode inject \
+        --lockfile=false \
         $d
 done

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -62,6 +62,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | n/a | `string` | `"10.0.0.0/8"` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_netnum_offset"></a> [netnum\_offset](#input\_netnum\_offset) | cidrsubnet netnum offset for the subnet. See https://developer.hashicorp.com/terraform/language/functions/cidrsubnet for more details | `number` | `0` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | The list of regions in which to provision subnets suitable for use with Cloud Run direct VPC egress. | `list(string)` | n/a | yes |
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_route" "egress-inet" {
 // which we will use to operate Cloud Run services.
 resource "google_compute_subnetwork" "regional" {
   for_each = {
-    for region in var.regions : region => 1 + index(var.regions, region)
+    for region in var.regions : region => index(var.regions, region)
   }
 
   name = "${var.name}-${each.key}"
@@ -30,5 +30,5 @@ resource "google_compute_subnetwork" "regional" {
 
   network       = google_compute_network.this.id
   region        = each.key
-  ip_cidr_range = cidrsubnet(var.cidr, 8, each.value)
+  ip_cidr_range = cidrsubnet(var.cidr, 8, var.netnum_offset + each.value)
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -14,3 +14,13 @@ variable "regions" {
 variable "cidr" {
   default = "10.0.0.0/8"
 }
+
+variable "netnum_offset" {
+  type    = number
+  default = 0
+  validation {
+    condition     = var.netnum_offset >= 0 && var.netnum_offset <= 255
+    error_message = "value must be between 0 and 255"
+  }
+  description = "cidrsubnet netnum offset for the subnet. See https://developer.hashicorp.com/terraform/language/functions/cidrsubnet for more details"
+}


### PR DESCRIPTION
Previously this would try to assign a CIDR block starting from 1.
e.g. given cidr = "10.0.0.0/8" and regions = ["a", "b"], you would get:

a: "10.1.0.0/16"
b: "10.2.0.0/16"

Since this always starts at 1, this makes it difficult to be able to select a subnet range. This change adds a field to start subnet numbering at a specific number (starting at 0).

e.g. with the previous example and netnum_offset = 10, you would now get:

a: "10.10.0.0/16"
b: "10.11.0.0/16"

This is a breaking change if downstream consumers are sensitive to subnet netnum needing to start at 1, but can easily be fixed by adding the netnum_offset. I think we want to do this long term so we don't leave IPs with 0 unassigned.