### PR TITLE
rgs: Add missing permissions for Cloud Run to connect to shared VPCs.

### DIFF
--- a/modules/regional-go-service/README.md
+++ b/modules/regional-go-service/README.md
@@ -83,8 +83,11 @@ No requirements.
 | [cosign_sign.this](https://registry.terraform.io/providers/chainguard-dev/cosign/latest/docs/resources/sign) | resource |
 | [google-beta_google_cloud_run_v2_service.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloud_run_v2_service) | resource |
 | [google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
-| [google_compute_subnetwork_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
+| [google_compute_subnetwork_iam_member.subnet_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
+| [google_project_iam_member.cloudrun_service_network_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.project_network_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [ko_build.this](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/build) | resource |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -155,17 +155,3 @@ resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthent
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
-
-// Grant service account access to use subnet. This is typically granted with roles/run.serviceAgent,
-// but that role does not necessarily grant access if the network resides in another project.
-// See https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#direct-vpc-service for more details.
-resource "google_compute_subnetwork_iam_member" "member" {
-  for_each = var.regions
-
-  // If not set, provider project should be used.
-  project    = var.network_project
-  region     = each.key
-  subnetwork = each.value.subnet
-  role       = "roles/compute.networkUser"
-  member     = "serviceAccount:${var.service_account}"
-}

--- a/modules/regional-go-service/network-iam.tf
+++ b/modules/regional-go-service/network-iam.tf
@@ -1,0 +1,37 @@
+// This file gramnts permissions for Cloud Run to access VPCs.
+// In particular, this is configured to support connecting to a shared VPC in another project,
+// but should be safe to apply in the same project.
+// See https://cloud.google.com/run/docs/configuring/shared-vpc-direct-vpc#set_up_iam_permissions for more details.
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+// Grant Cloud Run the service access to the network.
+resource "google_project_iam_member" "cloudrun_service_network_user" {
+  project = var.network_project
+  member  = "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com"
+  role    = "roles/compute.networkUser"
+}
+
+// Grant service account access to see networks on the network project.
+resource "google_project_iam_member" "project_network_viewer" {
+  project = var.network_project
+  member  = "serviceAccount:${var.service_account}"
+  role    = "roles/compute.networkViewer"
+}
+
+// Grant service account access to use subnet. This is typically granted with roles/run.serviceAgent,
+// but that role does not necessarily grant access if the network resides in another project.
+// See https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#direct-vpc-service for more details.
+resource "google_compute_subnetwork_iam_member" "subnet_network_user" {
+  for_each = var.regions
+
+  // If not set, provider project should be used.
+  project    = var.network_project
+  region     = each.key
+  subnetwork = each.value.subnet
+  role       = "roles/compute.networkUser"
+  member     = "serviceAccount:${var.service_account}"
+}
+


### PR DESCRIPTION
- Added roles/compute.networkUser for Cloud Run Service Agent (owned by Cloud Run itself)
- Added roles/compute.networkViewer for service account.

 See https://cloud.google.com/run/docs/configuring/shared-vpc-direct-vpc#set_up_iam_permissions