### PR TITLE
networking: Add option to create servicenetworking peer.

### DIFF
--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -47,6 +47,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [google_compute_global_address.nw-peer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
 | [google_compute_route.egress-inet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_route) | resource |
 | [google_compute_subnetwork.regional](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
@@ -54,6 +55,7 @@ No modules.
 | [google_dns_managed_zone.private-google-apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
 | [google_dns_record_set.cloud-run-cname](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_dns_record_set.private-googleapis-a-record](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_service_networking_connection.nw-peer-connect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 
 ## Inputs
@@ -61,6 +63,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | n/a | `string` | `"10.0.0.0/8"` | no |
+| <a name="input_create_servicenetworking_peer"></a> [create\_servicenetworking\_peer](#input\_create\_servicenetworking\_peer) | Whether to create a GCP service networking connection for the network. This should be disabled if the network is already peered with GCP private service networking. | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_netnum_offset"></a> [netnum\_offset](#input\_netnum\_offset) | cidrsubnet netnum offset for the subnet. See https://developer.hashicorp.com/terraform/language/functions/cidrsubnet for more details | `number` | `0` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -24,3 +24,9 @@ variable "netnum_offset" {
   }
   description = "cidrsubnet netnum offset for the subnet. See https://developer.hashicorp.com/terraform/language/functions/cidrsubnet for more details"
 }
+
+variable "create_servicenetworking_peer" {
+  type        = bool
+  description = "Whether to create a GCP service networking connection for the network. This should be disabled if the network is already peered with GCP private service networking."
+  default     = true
+}


### PR DESCRIPTION
Adds an option to create the private services peer for the network. This should be done once for the network.

See https://cloud.google.com/vpc/docs/configure-private-services-access#terraform for more details.