### PR TITLE
use only single band for latency graph

### DIFF
--- a/modules/dashboard/widgets/latency/main.tf
+++ b/modules/dashboard/widgets/latency/main.tf
@@ -1,10 +1,7 @@
 variable "title" { type = string }
 variable "group_by_fields" { default = [] }
 variable "filter" { type = list(string) }
-
-locals {
-  bands = [50, 95, 99]
-}
+variable "band" { type = number, default = 99 }
 
 // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#XyChart
 output "widget" {
@@ -12,17 +9,17 @@ output "widget" {
     title = var.title
     xyChart = {
       chartOptions = { mode = "COLOR" }
-      dataSets = [for band in local.bands : {
+      dataSets = [{
         minAlignmentPeriod = "60s"
         plotType           = "LINE"
         targetAxis         = "Y1"
-        legendTemplate     = "${band}th %ile"
+        legendTemplate     = "${var.band}th %ile"
         timeSeriesQuery = {
           timeSeriesFilter = {
             aggregation = {
               alignmentPeriod    = "60s"
               perSeriesAligner   = "ALIGN_DELTA"
-              crossSeriesReducer = "REDUCE_PERCENTILE_${band}"
+              crossSeriesReducer = "REDUCE_PERCENTILE_${var.band}"
               groupByFields      = var.group_by_fields
             }
             filter = join("\n", var.filter)


### PR DESCRIPTION
the latency widget defaulted to 3 bands, 50, 95, 99
when used in combination with group by fields, it becomes really noisy.
have it default to a single percentile, 99

this hopefully also reduces the load on dashboard page with fewer timeseries needing to be loaded.

this makes the percentile configurable.