### PR TITLE
change startup latency graph from line to stacked bar

### DIFF
--- a/modules/dashboard/sections/resources/main.tf
+++ b/modules/dashboard/sections/resources/main.tf
@@ -36,6 +36,7 @@ module "startup_latency" {
   filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/startup_latencies\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_MEAN"
+  plot_type      = "STACKED_BAR"
 }
 
 module "sent_bytes" {


### PR DESCRIPTION
making this a stacked bar graph as startup happens infrequently, causing the line graph to be very broken

bar graph will give a sense of how long startup was taking when it happens.