### PR TITLE
add error reporting widget and add it to service dashboard

### DIFF
--- a/modules/dashboard/sections/errgrp/README.md
+++ b/modules/dashboard/sections/errgrp/README.md
@@ -1,0 +1,36 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_collapsible"></a> [collapsible](#module\_collapsible) | ../collapsible | n/a |
+| <a name="module_errgrp"></a> [errgrp](#module\_errgrp) | ../../widgets/errgrp | n/a |
+| <a name="module_width"></a> [width](#module\_width) | ../width | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_collapsed"></a> [collapsed](#input\_collapsed) | n/a | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | n/a | `string` | n/a | yes |
+| <a name="input_title"></a> [title](#input\_title) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_section"></a> [section](#output\_section) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/dashboard/sections/errgrp/main.tf
+++ b/modules/dashboard/sections/errgrp/main.tf
@@ -1,0 +1,35 @@
+variable "title" { type = string }
+variable "collapsed" { default = false }
+variable "project_id" { type = string }
+variable "service_name" { type = string }
+
+module "width" { source = "../width" }
+
+module "errgrp" {
+  source       = "../../widgets/errgrp"
+  title        = var.title
+  project_id   = var.project_id
+  service_name = var.service_name
+}
+
+locals {
+  tiles = [{
+    yPos   = 0
+    xPos   = 0,
+    height = module.width.size,
+    width  = module.width.size / 4,
+    widget = module.errgrp.widget,
+  }]
+}
+
+module "collapsible" {
+  source = "../collapsible"
+
+  title     = var.title
+  tiles     = local.tiles
+  collapsed = var.collapsed
+}
+
+output "section" {
+  value = module.collapsible.section
+}

--- a/modules/dashboard/service/README.md
+++ b/modules/dashboard/service/README.md
@@ -62,6 +62,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alerts"></a> [alerts](#module\_alerts) | ../sections/alerts | n/a |
+| <a name="module_errgrp"></a> [errgrp](#module\_errgrp) | ../sections/errgrp | n/a |
 | <a name="module_grpc"></a> [grpc](#module\_grpc) | ../sections/grpc | n/a |
 | <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
@@ -81,6 +82,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alerts"></a> [alerts](#input\_alerts) | Alerting policies to add to the dashboard. | `list(string)` | `[]` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -1,3 +1,10 @@
+module "errgrp" {
+  source       = "../sections/errgrp"
+  title        = "Service Error Reporting"
+  project_id   = var.project_id
+  service_name = var.service_name
+}
+
 module "logs" {
   source = "../sections/logs"
   title  = "Service Logs"
@@ -39,6 +46,7 @@ module "layout" {
   sections = concat(
     [for x in var.alerts : module.alerts[x].section],
     [
+      module.errgrp.section,
       module.logs.section,
       module.http.section,
       module.grpc.section,

--- a/modules/dashboard/service/variables.tf
+++ b/modules/dashboard/service/variables.tf
@@ -14,3 +14,7 @@ variable "alerts" {
   default     = []
 }
 
+variable "project_id" {
+  description = "ID of the GCP project"
+  type        = string
+}

--- a/modules/dashboard/widgets/errgrp/README.md
+++ b/modules/dashboard/widgets/errgrp/README.md
@@ -1,0 +1,31 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | n/a | `string` | n/a | yes |
+| <a name="input_title"></a> [title](#input\_title) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_widget"></a> [widget](#output\_widget) | https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#ErrorReportingPanel |
+<!-- END_TF_DOCS -->

--- a/modules/dashboard/widgets/errgrp/main.tf
+++ b/modules/dashboard/widgets/errgrp/main.tf
@@ -1,0 +1,14 @@
+variable "title" { type = string }
+variable "project_id" { type = string }
+variable "service_name" { type = string }
+
+// https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#ErrorReportingPanel
+output "widget" {
+  value = {
+    title = var.title
+    errorReportingPanel = {
+      projectNames = ["projects/${var.project_id}"]
+      services     = [var.service_name]
+    }
+  }
+}

--- a/modules/dashboard/widgets/latency/main.tf
+++ b/modules/dashboard/widgets/latency/main.tf
@@ -1,7 +1,10 @@
 variable "title" { type = string }
 variable "group_by_fields" { default = [] }
 variable "filter" { type = list(string) }
-variable "band" { type = number, default = 99 }
+variable "band" {
+  type    = number
+  default = 99
+}
 
 // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#XyChart
 output "widget" {


### PR DESCRIPTION
will look something like below

![Screenshot 2024-01-31 at 8 30 15 PM](https://github.com/chainguard-dev/terraform-infra-common/assets/16194785/93a09142-7c84-48dd-ab16-d0d96e18f2e9)


cloud run has its own error reporting grouping, have it show in the dashboard
will cover various errors that cloudrun detects 


usage will need to be updated to pass in the project_id