### PR TITLE
fix height/width for errgrp widget in service dashboard

### DIFF
--- a/modules/dashboard/sections/errgrp/main.tf
+++ b/modules/dashboard/sections/errgrp/main.tf
@@ -16,8 +16,8 @@ locals {
   tiles = [{
     yPos   = 0
     xPos   = 0,
-    height = module.width.size,
-    width  = module.width.size / 4,
+    height = module.width.size / 4,
+    width  = module.width.size,
     widget = module.errgrp.widget,
   }]
 }


### PR DESCRIPTION
should be dividing by 4 on height not width.

[sample dash](https://console.cloud.google.com/monitoring/dashboards/builder/f7a35b30-7561-4fbf-bbe3-500d9c9dab52;duration=P1D?project=kleung-chainguard&supportedpurview=project&f.rlabel.service_name=enforce-registry)