### PR TITLE
Tune otel collector GMP exporter settings

### DIFF
--- a/modules/otel-collector/cmd/otel-collector/kodata/config.yaml
+++ b/modules/otel-collector/cmd/otel-collector/kodata/config.yaml
@@ -3,7 +3,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: "localhost"
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         # TODO: make this configurable
         - targets: ["localhost:2112"]
@@ -52,6 +52,7 @@ processors:
 
 exporters:
   googlemanagedprometheus:
+    untyped_double_export: true
     sending_queue:
       enabled: true
       # we are handling metrics for a single pod, no need to have
@@ -64,6 +65,7 @@ extensions:
 service:
   telemetry:
     logs:
+      encoding: "json"
       # We don't want to see scraper startup logging every
       # cold start.
       level: "error"


### PR DESCRIPTION
Some of these are based on the default settings from the official sidecar, which we should eventually switch over too.