### PR TITLE
Require `notification_channels` everywhere.

### DIFF
--- a/modules/audit-serviceaccount/README.md
+++ b/modules/audit-serviceaccount/README.md
@@ -64,7 +64,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_principal_regex"></a> [allowed\_principal\_regex](#input\_allowed\_principal\_regex) | A regular expression to match allowed principals. | `string` | `""` | no |
 | <a name="input_allowed_principals"></a> [allowed\_principals](#input\_allowed\_principals) | The list of principals authorized to assume this identity. | `list(string)` | `[]` | no |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The list of notification channels to alert when this policy fires. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The list of notification channels to alert when this policy fires. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_service-account"></a> [service-account](#input\_service-account) | The email of the service account being audited. | `string` | n/a | yes |
 

--- a/modules/audit-serviceaccount/variables.tf
+++ b/modules/audit-serviceaccount/variables.tf
@@ -22,5 +22,4 @@ variable "allowed_principal_regex" {
 variable "notification_channels" {
   description = "The list of notification channels to alert when this policy fires."
   type        = list(string)
-  default     = []
 }

--- a/modules/cloudevent-broker/README.md
+++ b/modules/cloudevent-broker/README.md
@@ -100,7 +100,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A pub/sub topic and ingress service (publishing to the respective topic) will be created in each region, with the ingress service configured to egress all traffic via the specified subnetwork. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -44,6 +44,8 @@ module "this" {
       }]
     }
   }
+
+  notification_channels = var.notification_channels
 }
 
 module "topic" {

--- a/modules/cloudevent-broker/variables.tf
+++ b/modules/cloudevent-broker/variables.tf
@@ -17,5 +17,4 @@ variable "regions" {
 variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
-  default     = []
 }

--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -98,7 +98,7 @@ No requirements.
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on data resources. | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the BigQuery dataset in, and in which to run the data transfer jobs from GCS. | `string` | `"US"` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert (for service-level issues). | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert (for service-level issues). | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_provisioner"></a> [provisioner](#input\_provisioner) | The identity as which this module will be applied (so it may be granted permission to 'act as' the DTS service account).  This should be in the form expected by an IAM subject (e.g. user:sally@example.com) | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A recorder service and cloud storage bucket (into which the service writes events) will be created in each region. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |

--- a/modules/cloudevent-recorder/bigquery.tf
+++ b/modules/cloudevent-recorder/bigquery.tf
@@ -84,7 +84,7 @@ module "audit-import-serviceaccount" {
   # Note: BigQuery DTS's usage doesn't show up in the
   # audit logs.
 
-  # TODO(mattmoor): plumb through notification channels.
+  notification_channels = var.notification_channels
 }
 
 // Create a BQ DTS job for each of the regions x types pulling from the appropriate buckets and paths.

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -66,6 +66,8 @@ module "this" {
     name      = "logs"
     empty_dir = {}
   }]
+
+  notification_channels = var.notification_channels
 }
 
 resource "random_id" "trigger-suffix" {
@@ -89,12 +91,14 @@ module "triggers" {
     region = each.value.region
     name   = var.name
   }
+
+  notification_channels = var.notification_channels
 }
 
 module "recorder-dashboard" {
   source       = "../dashboard/cloudevent-receiver"
   service_name = var.name
-  project_id = var.project_id
+  project_id   = var.project_id
 
   labels = { for type, schema in var.types : replace(type, ".", "_") => "" }
 

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -42,7 +42,6 @@ variable "broker" {
 variable "notification_channels" {
   description = "List of notification channels to alert (for service-level issues)."
   type        = list(string)
-  default     = []
 }
 
 variable "types" {

--- a/modules/cloudevent-trigger/README.md
+++ b/modules/cloudevent-trigger/README.md
@@ -104,6 +104,7 @@ No requirements.
 | <a name="input_filter"></a> [filter](#input\_filter) | A Knative Trigger-style filter over the cloud event attributes. | `map(string)` | n/a | yes |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_private-service"></a> [private-service](#input\_private-service) | The private cloud run service that is subscribing to these events. | <pre>object({<br>    name   = string<br>    region = string<br>  })</pre> | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 

--- a/modules/cloudevent-trigger/main.tf
+++ b/modules/cloudevent-trigger/main.tf
@@ -41,7 +41,7 @@ module "audit-trigger-serviceaccount" {
   # Note: Cloud Pub/Sub's usage doesn't show up in the
   # audit logs.
 
-  # TODO(mattmoor): plumb through notification channels.
+  notification_channels = var.notification_channels
 }
 
 // Authorize this service account to invoke the private service receiving

--- a/modules/cloudevent-trigger/variables.tf
+++ b/modules/cloudevent-trigger/variables.tf
@@ -29,3 +29,8 @@ variable "max_delivery_attempts" {
   type        = number
   default     = 5
 }
+
+variable "notification_channels" {
+  description = "List of notification channels to alert."
+  type        = list(string)
+}

--- a/modules/configmap/README.md
+++ b/modules/configmap/README.md
@@ -90,7 +90,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_data"></a> [data](#input\_data) | The data to place in the secret. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the secret. | `string` | n/a | yes |
-| <a name="input_notification-channels"></a> [notification-channels](#input\_notification-channels) | The channels to notify if the configuration data is improperly accessed. | `list(string)` | `[]` | no |
+| <a name="input_notification-channels"></a> [notification-channels](#input\_notification-channels) | The channels to notify if the configuration data is improperly accessed. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_service-account"></a> [service-account](#input\_service-account) | The email of the service account that will access the secret. | `string` | n/a | yes |
 

--- a/modules/configmap/variables.tf
+++ b/modules/configmap/variables.tf
@@ -20,5 +20,4 @@ variable "service-account" {
 variable "notification-channels" {
   description = "The channels to notify if the configuration data is improperly accessed."
   type        = list(string)
-  default     = []
 }

--- a/modules/cron/README.md
+++ b/modules/cron/README.md
@@ -97,6 +97,7 @@ No requirements.
 | <a name="input_max_retries"></a> [max\_retries](#input\_max\_retries) | The maximum number of times to retry the job. | `number` | `3` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory limit for the job. | `string` | `"512Mi"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix to created resources. | `any` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project that will host the cron job. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to run the job. | `string` | `"us-east4"` | no |
 | <a name="input_repository"></a> [repository](#input\_repository) | Container repository to publish images to. | `string` | `""` | no |

--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -32,7 +32,7 @@ module "audit-cronjob-serviceaccount" {
   # Note: Cloud Run's usage doesn't show up in the
   # audit logs.
 
-  # TODO(mattmoor): plumb through notification channels.
+  notification_channels = var.notification_channels
 }
 
 locals {

--- a/modules/cron/variables.tf
+++ b/modules/cron/variables.tf
@@ -121,3 +121,8 @@ variable "volume_mounts" {
   }))
   default = []
 }
+
+variable "notification_channels" {
+  description = "List of notification channels to alert."
+  type        = list(string)
+}

--- a/modules/dashboard/cloudevent-receiver/README.md
+++ b/modules/dashboard/cloudevent-receiver/README.md
@@ -103,7 +103,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alerts"></a> [alerts](#input\_alerts) | A mapping from alerting policy names to the alert ids to add to the dashboard. | `map(string)` | `{}` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 | <a name="input_triggers"></a> [triggers](#input\_triggers) | A mapping from a descriptive name to a subscription name prefix, an alert threshold, and list of notification channels. | <pre>map(object({<br>    subscription_prefix   = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>  }))</pre> | n/a | yes |

--- a/modules/dashboard/cloudevent-receiver/variables.tf
+++ b/modules/dashboard/cloudevent-receiver/variables.tf
@@ -25,7 +25,6 @@ variable "project_id" {
 variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
-  default     = []
 }
 
 variable "alerts" {

--- a/modules/dashboard/job/README.md
+++ b/modules/dashboard/job/README.md
@@ -61,7 +61,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_job_name"></a> [job\_name](#input\_job\_name) | Name of the job(s) to monitor | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/dashboard/job/variables.tf
+++ b/modules/dashboard/job/variables.tf
@@ -16,5 +16,4 @@ variable "project_id" {
 variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
-  default     = []
 }

--- a/modules/dashboard/sections/resources/main.tf
+++ b/modules/dashboard/sections/resources/main.tf
@@ -3,8 +3,7 @@ variable "filter" { type = list(string) }
 variable "cloudrun_name" { type = string }
 variable "collapsed" { default = false }
 variable "notification_channels" {
-  type    = list(string)
-  default = []
+  type = list(string)
 }
 
 module "width" { source = "../width" }

--- a/modules/dashboard/sections/subscription/main.tf
+++ b/modules/dashboard/sections/subscription/main.tf
@@ -2,8 +2,7 @@ variable "title" { type = string }
 variable "subscription_prefix" { type = string }
 variable "collapsed" { default = false }
 variable "notification_channels" {
-  type    = list(string)
-  default = []
+  type = list(string)
 }
 variable "alert_threshold" {
   type    = number

--- a/modules/dashboard/service/README.md
+++ b/modules/dashboard/service/README.md
@@ -82,7 +82,7 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alerts"></a> [alerts](#input\_alerts) | A mapping from alerting policy names to the alert ids to add to the dashboard. | `map(string)` | `{}` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 

--- a/modules/dashboard/service/variables.tf
+++ b/modules/dashboard/service/variables.tf
@@ -22,5 +22,4 @@ variable "project_id" {
 variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
-  default     = []
 }

--- a/modules/prober/README.md
+++ b/modules/prober/README.md
@@ -106,7 +106,7 @@ No requirements.
 | <a name="input_importpath"></a> [importpath](#input\_importpath) | The import path that contains the prober application. | `string` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory limit for the prober. | `string` | `"512Mi"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix to created resources. | `string` | n/a | yes |
-| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | A list of notification channels to send alerts to. | `list(string)` | `[]` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | A list of notification channels to send alerts to. | `list(string)` | n/a | yes |
 | <a name="input_period"></a> [period](#input\_period) | The period for the prober in seconds. | `string` | `"300s"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project that will host the prober. | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A prober service will be created in each region. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |

--- a/modules/prober/variables.tf
+++ b/modules/prober/variables.tf
@@ -96,7 +96,6 @@ variable "alert_description" {
 }
 
 variable "notification_channels" {
-  type        = list(string)
-  default     = []
   description = "A list of notification channels to send alerts to."
+  type        = list(string)
 }

--- a/modules/regional-go-service/README.md
+++ b/modules/regional-go-service/README.md
@@ -94,6 +94,7 @@ No requirements.
 | <a name="input_egress"></a> [egress](#input\_egress) | The egress mode for the service.  Must be one of ALL\_TRAFFIC, or PRIVATE\_RANGES\_ONLY. Egress traffic is routed through the regional VPC network from var.regions. | `string` | `"ALL_TRAFFIC"` | no |
 | <a name="input_ingress"></a> [ingress](#input\_ingress) | The ingress mode for the service.  Must be one of INGRESS\_TRAFFIC\_ALL, INGRESS\_TRAFFIC\_INTERNAL\_LOAD\_BALANCER, or INGRESS\_TRAFFIC\_INTERNAL\_ONLY. | `string` | `"INGRESS_TRAFFIC_INTERNAL_ONLY"` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A pub/sub topic and ingress service (publishing to the respective topic) will be created in each region, with the ingress service configured to egress all traffic via the specified subnetwork. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 | <a name="input_request_timeout_seconds"></a> [request\_timeout\_seconds](#input\_request\_timeout\_seconds) | The timeout for requests to the service, in seconds. | `number` | `300` | no |

--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -15,7 +15,7 @@ module "audit-serviceaccount" {
   # nothing is authorized to act as this service account.
   # Note: Cloud Run's usage doesn't show up in the audit logs.
 
-  # TODO(mattmoor): plumb through notification channels.
+  notification_channels = var.notification_channels
 }
 
 // Build each of the application images from source.

--- a/modules/regional-go-service/variables.tf
+++ b/modules/regional-go-service/variables.tf
@@ -115,3 +115,8 @@ variable "request_timeout_seconds" {
   type        = number
   default     = 300
 }
+
+variable "notification_channels" {
+  description = "List of notification channels to alert."
+  type        = list(string)
+}

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -89,7 +89,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_authorized-adder"></a> [authorized-adder](#input\_authorized-adder) | A member-style representation of the identity authorized to add new secret values (e.g. group:oncall@my-corp.dev). | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the secret. | `string` | n/a | yes |
-| <a name="input_notification-channels"></a> [notification-channels](#input\_notification-channels) | The channels to notify if the configuration data is improperly accessed. | `list(string)` | `[]` | no |
+| <a name="input_notification-channels"></a> [notification-channels](#input\_notification-channels) | The channels to notify if the configuration data is improperly accessed. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_service-account"></a> [service-account](#input\_service-account) | The email of the service account that will access the secret. | `string` | n/a | yes |
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -20,5 +20,4 @@ variable "service-account" {
 variable "notification-channels" {
   description = "The channels to notify if the configuration data is improperly accessed."
   type        = list(string)
-  default     = []
 }


### PR DESCRIPTION
This change makes us require `notification_channels` everywhere we accept it (or should!) to force ourselves to pass `[]` in places where we explicitly want to NACK the alerts a module may surface.