### PR TITLE
Expand the data access query

### DIFF
--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -185,10 +185,14 @@ resource "google_monitoring_alert_policy" "anomalous-secret-access" {
 
     condition_matched_log {
       filter = <<EOT
+      logName="projects/${var.project_id}/logs/cloudaudit.googleapis.com%2Fdata_access"
       protoPayload.serviceName="run.googleapis.com"
-      protoPayload.resourceName=("${join("\" OR \"", [
+      protoPayload.resourceName=("${join("\" OR \"", concat([
+        "namespaces/${var.project_id}/services/${var.name}"
+      ],
+      [
         for region in keys(var.regions) : "projects/${var.project_id}/locations/${region}/services/${var.name}"
-      ])}")
+      ]))}")
 
       -- Allow CI to reconcile services and IAM policies.
       -(


### PR DESCRIPTION
It appears that Cloud Run v1 entries have a different shape in the audit logs.