### PR TITLE
bucket-events: add dashboard

### DIFF
--- a/modules/bucket-events/README.md
+++ b/modules/bucket-events/README.md
@@ -58,14 +58,21 @@ No requirements.
 |------|--------|---------|
 | <a name="module_audit-delivery-serviceaccount"></a> [audit-delivery-serviceaccount](#module\_audit-delivery-serviceaccount) | ../audit-serviceaccount | n/a |
 | <a name="module_authorize-delivery"></a> [authorize-delivery](#module\_authorize-delivery) | ../authorize-private-service | n/a |
+| <a name="module_http"></a> [http](#module\_http) | ../dashboard/sections/http | n/a |
+| <a name="module_layout"></a> [layout](#module\_layout) | ../dashboard/sections/layout | n/a |
+| <a name="module_logs"></a> [logs](#module\_logs) | ../dashboard/sections/logs | n/a |
+| <a name="module_resources"></a> [resources](#module\_resources) | ../dashboard/sections/resources | n/a |
 | <a name="module_this"></a> [this](#module\_this) | ../regional-go-service | n/a |
+| <a name="module_topic"></a> [topic](#module\_topic) | ../dashboard/sections/topic | n/a |
 | <a name="module_trampoline-emits-events"></a> [trampoline-emits-events](#module\_trampoline-emits-events) | ../authorize-private-service | n/a |
+| <a name="module_width"></a> [width](#module\_width) | ../dashboard/sections/width | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [google-beta_google_project_service_identity.pubsub](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
+| [google_monitoring_dashboard.dashboard](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
 | [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_binding.allow-pubsub-to-ack](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
 | [google_pubsub_topic.dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |

--- a/modules/bucket-events/dashboard.tf
+++ b/modules/bucket-events/dashboard.tf
@@ -1,0 +1,60 @@
+module "topic" {
+  source       = "../dashboard/sections/topic"
+  title        = "Notification Topic"
+  topic_prefix = var.name
+}
+
+module "logs" {
+  source = "../dashboard/sections/logs"
+  title  = "Service Logs"
+  filter = ["resource.type=\"cloud_run_revision\""]
+}
+
+module "http" {
+  source       = "../dashboard/sections/http"
+  title        = "HTTP"
+  filter       = ["resource.type=\"cloud_run_revision\""]
+  service_name = var.name
+}
+
+module "resources" {
+  source        = "../dashboard/sections/resources"
+  title         = "Resources"
+  filter        = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}\""]
+  cloudrun_name = var.name
+
+  notification_channels = var.notification_channels
+}
+
+module "width" { source = "../dashboard/sections/width" }
+
+module "layout" {
+  source = "../dashboard/sections/layout"
+  sections = [
+    module.topic.section,
+    module.logs.section,
+    module.http.section,
+    module.resources.section,
+  ]
+}
+
+resource "google_monitoring_dashboard" "dashboard" {
+  dashboard_json = jsonencode({
+    displayName = "GCS Bucket Events: ${var.bucket} in ${local.region}"
+    labels = {
+      "storage" : ""
+      "eventing" : ""
+    }
+    dashboardFilters = [{
+      filterType  = "RESOURCE_LABEL"
+      stringValue = var.name
+      labelKey    = "service_name"
+    }]
+
+    // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
+    mosaicLayout = {
+      columns = module.width.size
+      tiles   = module.layout.tiles,
+    }
+  })
+}


### PR DESCRIPTION
This is basically copy/paste from the broker's ingress dashboard.

Example: https://console.cloud.google.com/monitoring/dashboards/builder/1907212f-1f10-4e62-994f-e37694a766e7;duration=PT15M?project=jason-chainguard&f.rlabel.service_name=bucket-events

<img width="1663" alt="Screenshot 2024-02-24 at 8 44 47 PM" src="https://github.com/chainguard-dev/terraform-infra-common/assets/210737/915716be-c659-4ad1-b629-4686a54aed64">
