### PR TITLE
cloudevent-trigger: support filter prefix

### DIFF
--- a/modules/cloudevent-trigger/README.md
+++ b/modules/cloudevent-trigger/README.md
@@ -102,7 +102,8 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_broker"></a> [broker](#input\_broker) | The name of the pubsub topic we are using as a broker. | `string` | n/a | yes |
-| <a name="input_filter"></a> [filter](#input\_filter) | A Knative Trigger-style filter over the cloud event attributes. | `map(string)` | n/a | yes |
+| <a name="input_filter"></a> [filter](#input\_filter) | A Knative Trigger-style filter over the cloud event attributes.<br><br>This is normally used to filter relevant event types:<br><br>  { "type" : "dev.chainguard.foo" } | `map(string)` | `{}` | no |
+| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | A Knative Trigger-style filter over the cloud event attribute prefixes.<br><br>If an event may have a "source" attribute "foo.bar" or "foo.baz" and the filter is<br><br>  { source = "foo." }<br><br>then both events will be delivered to the service. | `map(string)` | `{}` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |

--- a/modules/cloudevent-trigger/README.md
+++ b/modules/cloudevent-trigger/README.md
@@ -102,8 +102,8 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_broker"></a> [broker](#input\_broker) | The name of the pubsub topic we are using as a broker. | `string` | n/a | yes |
-| <a name="input_filter"></a> [filter](#input\_filter) | A Knative Trigger-style filter over the cloud event attributes.<br><br>This is normally used to filter relevant event types:<br><br>  { "type" : "dev.chainguard.foo" } | `map(string)` | `{}` | no |
-| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | A Knative Trigger-style filter over the cloud event attribute prefixes.<br><br>If an event may have a "source" attribute "foo.bar" or "foo.baz" and the filter is<br><br>  { source = "foo." }<br><br>then both events will be delivered to the service. | `map(string)` | `{}` | no |
+| <a name="input_filter"></a> [filter](#input\_filter) | A Knative Trigger-style filter over the cloud event attributes.<br><br>This is normally used to filter relevant event types, for example:<br><br>  { "type" : "dev.chainguard.foo" }<br><br>In this case, only events with a type attribute of "dev.chainguard.foo" will be delivered. | `map(string)` | `{}` | no |
+| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | A Knative Trigger-style filter over the cloud event attribute prefixes.<br><br>This can be used to filter relevant event types, for example:<br><br>  { "type" : "dev.chainguard." }<br><br>In this case, any event with a type attribute that starts with "dev.chainguard." will be delivered. | `map(string)` | `{}` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |

--- a/modules/cloudevent-trigger/main.tf
+++ b/modules/cloudevent-trigger/main.tf
@@ -57,9 +57,11 @@ module "authorize-delivery" {
 }
 
 locals {
-  filter-elements = [
-    for key, value in var.filter : "attributes.ce-${key}=\"${value}\""
-  ]
+  // See https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax
+  filter-elements = concat(
+    [for key, value in var.filter : "attributes.ce-${key}=\"${value}\""],
+    [for key, value in var.filter_prefix : "hasPrefix(attributes.ce-${key}, \"${value}\""],
+  )
 }
 
 resource "google_pubsub_topic" "dead-letter" {

--- a/modules/cloudevent-trigger/variables.tf
+++ b/modules/cloudevent-trigger/variables.tf
@@ -15,10 +15,11 @@ variable "filter" {
   description = <<EOD
 A Knative Trigger-style filter over the cloud event attributes.
 
-This is normally used to filter relevant event types:
+This is normally used to filter relevant event types, for example:
 
   { "type" : "dev.chainguard.foo" }
 
+In this case, only events with a type attribute of "dev.chainguard.foo" will be delivered.
 EOD
   type        = map(string)
   default     = {}
@@ -28,11 +29,11 @@ variable "filter_prefix" {
   description = <<EOD
 A Knative Trigger-style filter over the cloud event attribute prefixes.
 
-If an event may have a "source" attribute "foo.bar" or "foo.baz" and the filter is
+This can be used to filter relevant event types, for example:
 
-  { source = "foo." }
+  { "type" : "dev.chainguard." }
 
-then both events will be delivered to the service.
+In this case, any event with a type attribute that starts with "dev.chainguard." will be delivered.
 EOD
   type        = map(string)
   default     = {}

--- a/modules/cloudevent-trigger/variables.tf
+++ b/modules/cloudevent-trigger/variables.tf
@@ -12,8 +12,30 @@ variable "broker" {
 }
 
 variable "filter" {
-  description = "A Knative Trigger-style filter over the cloud event attributes."
+  description = <<EOD
+A Knative Trigger-style filter over the cloud event attributes.
+
+This is normally used to filter relevant event types:
+
+  { "type" : "dev.chainguard.foo" }
+
+EOD
   type        = map(string)
+  default     = {}
+}
+
+variable "filter_prefix" {
+  description = <<EOD
+A Knative Trigger-style filter over the cloud event attribute prefixes.
+
+If an event may have a "source" attribute "foo.bar" or "foo.baz" and the filter is
+
+  { source = "foo." }
+
+then both events will be delivered to the service.
+EOD
+  type        = map(string)
+  default     = {}
 }
 
 variable "private-service" {


### PR DESCRIPTION
https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax

This adds a new input var, `filter_prefix`, which works like `filter` but with attribute prefixes instead of exact matches.