### PR TITLE
Add an alert policy around the recorder's GCS bucket

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -79,6 +79,7 @@ No requirements.
 | [google_bigquery_table.types](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) | resource |
 | [google_bigquery_table_iam_binding.import-writes-to-tables](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_binding) | resource |
 | [google_monitoring_alert_policy.bq_dts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.bucket-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_service_account.import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.recorder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.bq-dts-assumes-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
@@ -88,6 +89,7 @@ No requirements.
 | [google_storage_bucket_iam_binding.recorder-writes-to-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.trigger-suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_client_openid_userinfo.me](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/modules/cloudevent-recorder/main.tf
+++ b/modules/cloudevent-recorder/main.tf
@@ -46,3 +46,59 @@ resource "google_storage_bucket" "recorder" {
     }
   }
 }
+
+// What identity is deploying this?
+data "google_client_openid_userinfo" "me" {}
+
+resource "google_monitoring_alert_policy" "bucket-access" {
+  # In the absence of data, incident will auto-close after an hour
+  alert_strategy {
+    auto_close = "3600s"
+
+    notification_rate_limit {
+      period = "3600s" // re-alert hourly if condition still valid.
+    }
+  }
+
+  display_name = "Abnormal Event Bucket Access: ${var.name}"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Bucket Access"
+
+    condition_matched_log {
+      filter = <<EOT
+      logName="projects/${var.project_id}/logs/cloudaudit.googleapis.com%2Fdata_access"
+      protoPayload.serviceName="storage.googleapis.com"
+      protoPayload.resourceName=~"projects/_/buckets/${var.name}-(${join("|", keys(var.regions))})-${random_id.suffix.hex}"
+
+      -- The recorder service write objects into the bucket.
+      -(
+        protoPayload.authenticationInfo.principalEmail="${google_service_account.recorder.email}"
+        protoPayload.methodName="storage.objects.create"
+      )
+
+      -- The importer identity (used by DTS) enumerates and reads objects.
+      -(
+        protoPayload.authenticationInfo.principalEmail="${google_service_account.import-identity.email}"
+        protoPayload.methodName=("storage.objects.get" OR "storage.objects.list" OR "storage.buckets.get")
+      )
+
+      -- Our CI identity reconciles the bucket.
+      -(
+        protoPayload.authenticationInfo.principalEmail="${data.google_client_openid_userinfo.me.email}"
+        protoPayload.methodName=("storage.buckets.get" OR "storage.getIamPermissions")
+      )
+      EOT
+
+      label_extractors = {
+        "subject" = "EXTRACT(protoPayload.authenticationInfo.principalSubject)"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+
+  enabled = "true"
+  project = var.project_id
+}


### PR DESCRIPTION
This creates an alert policy around the GCS bucket that sits between the recorder and BQ DTS to ensure that nothing outside of this module is mucking with our implementation details.

Fixes: https://github.com/chainguard-dev/terraform-infra-common/issues/146