### PR TITLE
Add GitHub->GSA federation helper modules.

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -28,6 +28,8 @@ jobs:
           - cron
           - configmap
           - secret
+          - github-wif-provider
+          - github-gsa
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -28,6 +28,8 @@ jobs:
           - cron
           - configmap
           - secret
+          - github-wif-provider
+          - github-gsa
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/modules/github-gsa/README.md
+++ b/modules/github-gsa/README.md
@@ -1,0 +1,75 @@
+# `github-gsa`
+
+This module creates a Google Service Account that can be assumed by particular
+GitHub Actions workflows. It is intended to be used in conjunction with the
+[`github-wif-provider` module](./github-wif-provider/README.md).
+
+```hcl
+module "github-wif" {
+  source = "chainguard-dev/common/infra//modules/github-wif-provider"
+
+  project_id = var.project_id
+  name       = "my-wif-pool"
+
+  notification_channels = var.notification_channels
+}
+
+module "foo" {
+  source = "chainguard-dev/common/infra//modules/github-gsa"
+
+  project_id = var.project_id
+  name       = "foo"
+  wif-pool   = module.github-wif.pool_name
+
+  repository   = "the-org/the-repo"
+  refspec      = "refs/heads/main"
+  workflow_ref = ".github/workflows/my-workflow.yaml"
+
+  notification_channels = var.notification_channels
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_audit-usage"></a> [audit-usage](#module\_audit-usage) | ../audit-serviceaccount | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.allow-impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_audit_refspec"></a> [audit\_refspec](#input\_audit\_refspec) | The regular expression to use for auditing the refspec component when using '*' | `string` | `""` | no |
+| <a name="input_audit_workflow_ref"></a> [audit\_workflow\_ref](#input\_audit\_workflow\_ref) | The regular expression to use for auditing the workflow ref component when using '*' | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name to give the service account. | `string` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The list of notification channels to alert when the service account is misused. | `list(string)` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_refspec"></a> [refspec](#input\_refspec) | The refspec to allow to federate with this identity. | `string` | n/a | yes |
+| <a name="input_repository"></a> [repository](#input\_repository) | The name of the repository to allow to assume this identity. | `string` | n/a | yes |
+| <a name="input_wif-pool"></a> [wif-pool](#input\_wif-pool) | The name of the Workload Identity Federation pool. | `string` | n/a | yes |
+| <a name="input_workflow_ref"></a> [workflow\_ref](#input\_workflow\_ref) | The workflow to allow to federate with this identity (e.g. .github/workflows/deploy.yaml). | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_email"></a> [email](#output\_email) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/github-gsa/main.tf
+++ b/modules/github-gsa/main.tf
@@ -1,0 +1,147 @@
+// Create the actual service account.
+resource "google_service_account" "this" {
+  project    = var.project_id
+  account_id = var.name
+}
+
+locals {
+  # Build up the "ref" portion of the principal match regular expression.
+  refPart = (var.refspec == "*") ? (
+    (var.audit_refspec != "") ? (
+      var.audit_refspec
+      ) : (
+      "[^|]+"
+    )
+    ) : (
+    (var.refspec == "pull_request") ? (
+      "refs/pulls/[0-9]+/merge"
+      ) : (
+      (var.refspec == "version_tags") ? (
+        "refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?"
+        ) : (
+        # TODO(mattmoor): How can we "quote" this?
+        var.refspec
+      )
+    )
+  )
+  # Build up the "workflow" portion of the principal match regular expression.
+  workflowPart = (var.workflow_ref == "*") ? (
+    (var.audit_workflow_ref != "") ? (
+      var.audit_workflow_ref
+      ) : (
+      "[^|]+"
+    )
+    ) : (
+    # TODO(mattmoor): How can we "quote" this?
+    var.workflow_ref
+  )
+  # TODO(mattmoor): How can we "quote" the `wif-pool` here?
+  principalSubject = "^principal://iam\\.googleapis\\.com/${var.wif-pool}/subject/${join("\\\\|", [
+    var.repository,
+    local.refPart,
+    local.workflowPart,
+  ])}$"
+
+  exact = "attribute.exact/${join("|", [
+    var.repository,
+    var.refspec,
+    "${var.repository}/${var.workflow_ref}",
+  ])}"
+
+  exact-any-ref = "attribute.exactanyref/${join("|", [
+    var.repository,
+    "${var.repository}/${var.workflow_ref}",
+  ])}"
+
+  exact-any-ref-any-workflow = "attribute.exactanyrefanyworkflow/${var.repository}"
+
+  exact-any-workflow = "attribute.exactanyworkflow/${join("|", [
+    var.repository,
+    var.refspec,
+  ])}"
+
+  pull-request = "attribute.pullrequest/${join("|", [
+    var.repository,
+    "true",
+    "${var.repository}/${var.workflow_ref}",
+  ])}"
+
+  pull-request-any-workflow = "attribute.pullrequestanyworkflow/${join("|", [
+    var.repository,
+    "true",
+  ])}"
+
+  version-tags = "attribute.versiontags/${join("|", [
+    var.repository,
+    "true",
+    "${var.repository}/${var.workflow_ref}",
+  ])}"
+
+  version-tags-any-workflow = "attribute.versiontagsanyworkflow/${join("|", [
+    var.repository,
+    "true",
+  ])}"
+
+  attribute-match = var.refspec == "*" ? (
+    var.workflow_ref == "*" ? (
+      local.exact-any-ref-any-workflow
+      ) : (
+      local.exact-any-ref
+    )
+    ) : (
+    var.refspec == "pull_request" ? (
+      var.workflow_ref == "*" ? (
+        local.pull-request-any-workflow
+        ) : (
+        local.pull-request
+      )
+      ) : (
+      var.refspec == "version_tags" ? (
+        var.workflow_ref == "*" ? (
+          local.version-tags-any-workflow
+          ) : (
+          local.version-tags
+        )
+        ) : (
+        var.workflow_ref == "*" ? (
+          local.exact-any-workflow
+          ) : (
+          local.exact
+        )
+      )
+    )
+  )
+}
+
+// Create the IAM binding allowing workflows to impersonate the service account.
+resource "google_service_account_iam_binding" "allow-impersonation" {
+  service_account_id = google_service_account.this.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/${var.wif-pool}/${local.attribute-match}",
+  ]
+
+  lifecycle {
+    precondition {
+      condition = var.audit_workflow_ref == "" || var.workflow_ref == "*"
+      error_message = "audit_workflow_ref may only be specified when workflow_ref is '*'"
+    }
+    precondition {
+      condition = var.audit_refspec == "" || var.refspec == "*"
+      error_message = "audit_refspec may only be specified when refspec is '*'"
+    }
+  }
+}
+
+// Create an auditing policy to ensure that tokens are only issued for identities
+// matching our expectations.
+module "audit-usage" {
+  source = "../audit-serviceaccount"
+
+  project_id      = var.project_id
+  service-account = google_service_account.this.email
+
+  allowed_principal_regex = local.principalSubject
+  notification_channels   = var.notification_channels
+}

--- a/modules/github-gsa/outputs.tf
+++ b/modules/github-gsa/outputs.tf
@@ -1,0 +1,3 @@
+output "email" {
+  value = google_service_account.this.email
+}

--- a/modules/github-gsa/variables.tf
+++ b/modules/github-gsa/variables.tf
@@ -1,0 +1,52 @@
+variable "project_id" {
+  type = string
+}
+
+variable "name" {
+  description = "The name to give the service account."
+  type        = string
+}
+
+variable "wif-pool" {
+  description = "The name of the Workload Identity Federation pool."
+  type        = string
+}
+
+variable "repository" {
+  description = "The name of the repository to allow to assume this identity."
+  type        = string
+}
+
+variable "refspec" {
+  description = "The refspec to allow to federate with this identity."
+  type        = string
+  validation {
+    condition     = var.refspec == "*" || var.refspec == "pull_request" || var.refspec == "version_tags" || startswith(var.refspec, "refs/")
+    error_message = "Expected '*', 'pull_request', 'version_tags' or a refspec of the form 'refs/heads/main', but got '${var.refspec}'."
+  }
+}
+variable "audit_refspec" {
+  description = "The regular expression to use for auditing the refspec component when using '*'"
+  type        = string
+  default     = ""
+}
+
+variable "workflow_ref" {
+  description = "The workflow to allow to federate with this identity (e.g. .github/workflows/deploy.yaml)."
+  type        = string
+  validation {
+    condition     = var.workflow_ref == "*" || startswith(var.workflow_ref, ".github/workflows/")
+    error_message = "Expected '*' or a path of the form '.github/workflows/foo.yaml', but got '${var.workflow_ref}'."
+  }
+}
+
+variable "audit_workflow_ref" {
+  description = "The regular expression to use for auditing the workflow ref component when using '*'"
+  type        = string
+  default     = ""
+}
+
+variable "notification_channels" {
+  description = "The list of notification channels to alert when the service account is misused."
+  type        = list(string)
+}

--- a/modules/github-wif-provider/README.md
+++ b/modules/github-wif-provider/README.md
@@ -1,0 +1,43 @@
+# `github-wif-provider`
+
+This module sets up a Google Workload Identity Pool and Provider that are set up
+to project the GitHub token's claims into attributes in a way that the
+[`github-gsa`](../github-gsa/README.md) can match to authorize access.  For
+examples of how these are used together see the `github-gsa` README.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_iam_workload_identity_pool.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool) | resource |
+| [google-beta_google_iam_workload_identity_pool_provider.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_iam_workload_identity_pool_provider) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | The name to give the provider pool. | `string` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The list of notification channels to alert when this policy fires. | `list(string)` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_pool_name"></a> [pool\_name](#output\_pool\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -1,0 +1,44 @@
+resource "google_iam_workload_identity_pool" "this" {
+  project                   = var.project_id
+  provider                  = google-beta
+  workload_identity_pool_id = var.name
+  display_name              = "Pool for ${var.name}"
+}
+
+resource "google_iam_workload_identity_pool_provider" "this" {
+  project                            = var.project_id
+  provider                           = google-beta
+  workload_identity_pool_id          = google_iam_workload_identity_pool.this.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-provider" # This gets 4-32 alphanumeric characters (and '-')
+  display_name                       = "GitHub provider"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  # ref: https://cloud.google.com/iam/docs/workload-identity-federation#mapping
+  # ref: https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions
+  attribute_mapping = {
+    # Don't use the GitHub subject because it it less specific than ours, which also captures:
+    #   - The pull request number via `refs/pulls/N/merge`, and
+    #   - The worflow file.
+    "google.subject" = "assertion.repository + '|' + assertion.ref + '|' + assertion.workflow_ref.split('@')[0]"
+
+    # assertion.ref has one of the forms:
+    #   - Branch: refs/heads/main
+    #   - Pull Request: refs/pull/1/merge
+    #   - Tag: refs/tags/v1.0.0
+    # assertion.workflow_ref has one of the forms:
+    #   - .github/workflows/secrets.yaml@refs/heads/main
+    #   - .github/workflows/secrets.yaml@refs/tags/v1.0.0
+    #   - .github/workflows/secrets.yaml@refs/pull/1/merge
+    "attribute.exact"                  = "assertion.repository + '|' + assertion.ref + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.exactanyref"            = "assertion.repository + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.exactanyrefanyworkflow" = "assertion.repository"
+    "attribute.exactanyworkflow"       = "assertion.repository + '|' + assertion.ref"
+    "attribute.pullrequest"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.pullrequestanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false')"
+    "attribute.versiontags"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.versiontagsanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false')"
+  }
+}

--- a/modules/github-wif-provider/outputs.tf
+++ b/modules/github-wif-provider/outputs.tf
@@ -1,0 +1,3 @@
+output "pool_name" {
+  value = google_iam_workload_identity_pool.this.name
+}

--- a/modules/github-wif-provider/variables.tf
+++ b/modules/github-wif-provider/variables.tf
@@ -1,0 +1,13 @@
+variable "project_id" {
+  type = string
+}
+
+variable "name" {
+  description = "The name to give the provider pool."
+  type        = string
+}
+
+variable "notification_channels" {
+  description = "The list of notification channels to alert when this policy fires."
+  type        = list(string)
+}


### PR DESCRIPTION
There are two key modules that work in concert:
1. A provider module, which sets up attribute mappings in a way that we can access interesting claims and do some fuzzy matching,
2. A service account module, which provisions Google Service Accounts that can be provisioned by providers created with the above.

These rules are intended to encapsulate some of the heroics that folks must currently do with CEL to try and get workflow-level authorization to assume particular GSA's, and give us a stronger "subject" for how these workflows appear as principals in audit logs.