### PR TITLE
Add a few outputs to `cloudevent-recorder`

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -109,5 +109,8 @@ No requirements.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_dataset_id"></a> [dataset\_id](#output\_dataset\_id) | n/a |
+| <a name="output_table_ids"></a> [table\_ids](#output\_table\_ids) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/cloudevent-recorder/outputs.tf
+++ b/modules/cloudevent-recorder/outputs.tf
@@ -1,0 +1,9 @@
+output "dataset_id" {
+  value = google_bigquery_dataset.this.dataset_id
+}
+
+output "table_ids" {
+  value = {
+    for k, v in google_bigquery_table.types : k => v.table_id
+  }
+}


### PR DESCRIPTION
This is to let us use `google_bigquery_table` to create views of the data once the dataset is created.