### PR TITLE
used wrong index, needed to duplicate the key, ${region}-${type} for the transfer config

### DIFF
--- a/modules/cloudevent-recorder/bigquery.tf
+++ b/modules/cloudevent-recorder/bigquery.tf
@@ -143,7 +143,7 @@ resource "google_monitoring_alert_policy" "bq_dts" {
         AND metric.type = "bigquerydatatransfer.googleapis.com/transfer_config/completed_runs"
         AND metric.labels.completion_state = "SUCCEEDED"
         AND metric.labels.run_cause = "AUTO_SCHEDULE"
-        AND resource.labels.config_id = "${element(reverse(split("/", google_bigquery_data_transfer_config.import-job[conditions.key].name)), 0)}"
+        AND resource.labels.config_id = "${element(reverse(split("/", google_bigquery_data_transfer_config.import-job["${conditions.key}-${each.key}"].name)), 0)}"
         EOT
 
         trigger {


### PR DESCRIPTION
```
Error: Invalid index

  on .terraform/modules/event-recorder-cloudrun/modules/cloudevent-recorder/bigquery.tf line 146, in resource "google_monitoring_alert_policy" "bq_dts":
 146:         AND resource.labels.config_id = "${element(reverse(split("/", google_bigquery_data_transfer_config.import-job[conditions.key].name)), 0)}"
    ├────────────────
    │ conditions.key is "us-central1"
    │ google_bigquery_data_transfer_config.import-job is object with 6 attributes

The given key does not identify an element in this collection value.
```