### PR TITLE
[cloudevent-recorder] Add partition_field option.

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -102,7 +102,7 @@ No requirements.
 | <a name="input_provisioner"></a> [provisioner](#input\_provisioner) | The identity as which this module will be applied (so it may be granted permission to 'act as' the DTS service account).  This should be in the form expected by an IAM subject (e.g. user:sally@example.com) | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A recorder service and cloud storage bucket (into which the service writes events) will be created in each region. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 | <a name="input_retention-period"></a> [retention-period](#input\_retention-period) | The number of days to retain data in BigQuery. | `number` | n/a | yes |
-| <a name="input_types"></a> [types](#input\_types) | A map from cloudevent types to the BigQuery schema associated with them, as well as an alert threshold and a list of notification channels (for subscription-level issues). | <pre>map(object({<br>    schema                = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>  }))</pre> | n/a | yes |
+| <a name="input_types"></a> [types](#input\_types) | A map from cloudevent types to the BigQuery schema associated with them, as well as an alert threshold and a list of notification channels (for subscription-level issues). | <pre>map(object({<br>    schema                = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>    partition_field       = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/cloudevent-recorder/bigquery.tf
+++ b/modules/cloudevent-recorder/bigquery.tf
@@ -20,7 +20,8 @@ resource "google_bigquery_table" "types" {
   require_partition_filter = false
 
   time_partitioning {
-    type = "DAY"
+    type  = "DAY"
+    field = each.value.partition_field
 
     expiration_ms = (var.retention-period) * 24 * 60 * 60 * 1000
   }

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -52,5 +52,6 @@ variable "types" {
     schema                = string
     alert_threshold       = optional(number, 50000)
     notification_channels = optional(list(string), [])
+    partition_field       = optional(string)
   }))
 }

--- a/modules/dashboard/sections/resources/README.md
+++ b/modules/dashboard/sections/resources/README.md
@@ -5,7 +5,9 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
 
 ## Modules
 
@@ -15,6 +17,7 @@ No providers.
 | <a name="module_cpu_utilization"></a> [cpu\_utilization](#module\_cpu\_utilization) | ../../widgets/xy | n/a |
 | <a name="module_instance_count"></a> [instance\_count](#module\_instance\_count) | ../../widgets/xy | n/a |
 | <a name="module_memory_utilization"></a> [memory\_utilization](#module\_memory\_utilization) | ../../widgets/xy | n/a |
+| <a name="module_oom_alert"></a> [oom\_alert](#module\_oom\_alert) | ../../widgets/alert | n/a |
 | <a name="module_received_bytes"></a> [received\_bytes](#module\_received\_bytes) | ../../widgets/xy | n/a |
 | <a name="module_sent_bytes"></a> [sent\_bytes](#module\_sent\_bytes) | ../../widgets/xy | n/a |
 | <a name="module_startup_latency"></a> [startup\_latency](#module\_startup\_latency) | ../../widgets/xy | n/a |
@@ -22,14 +25,18 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_monitoring_alert_policy.oom](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudrun_name"></a> [cloudrun\_name](#input\_cloudrun\_name) | n/a | `string` | n/a | yes |
 | <a name="input_collapsed"></a> [collapsed](#input\_collapsed) | n/a | `bool` | `false` | no |
 | <a name="input_filter"></a> [filter](#input\_filter) | n/a | `list(string)` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | n/a | `list(string)` | `[]` | no |
 | <a name="input_title"></a> [title](#input\_title) | n/a | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/dashboard/widgets/latency/README.md
+++ b/modules/dashboard/widgets/latency/README.md
@@ -19,6 +19,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_band"></a> [band](#input\_band) | n/a | `number` | `99` | no |
 | <a name="input_filter"></a> [filter](#input\_filter) | n/a | `list(string)` | n/a | yes |
 | <a name="input_group_by_fields"></a> [group\_by\_fields](#input\_group\_by\_fields) | n/a | `list` | `[]` | no |
 | <a name="input_title"></a> [title](#input\_title) | n/a | `string` | n/a | yes |


### PR DESCRIPTION
Allows callers to pass in an optional partition field to instruct BQ for how to partition the data. If omitted, default behavior is used (import time).