### PR TITLE
monitoring: alerting when cloud run revision fails to rollout

### DIFF
--- a/modules/regional-go-service/README.md
+++ b/modules/regional-go-service/README.md
@@ -85,6 +85,7 @@ No requirements.
 | [google-beta_google_cloud_run_v2_service.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloud_run_v2_service) | resource |
 | [google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
 | [google_monitoring_alert_policy.anomalous-service-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.bad-rollout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [ko_build.this](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/build) | resource |
 | [google_client_openid_userinfo.me](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |

--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -245,6 +245,44 @@ resource "google_monitoring_alert_policy" "anomalous-service-access" {
   project = var.project_id
 }
 
+// Create an alert policy to notify if the service is struggling to rollout.
+resource "google_monitoring_alert_policy" "bad-rollout" {
+  # In the absence of data, incident will auto-close after an hour
+  alert_strategy {
+    auto_close = "3600s"
+
+    notification_rate_limit {
+      period = "3600s" // re-alert hourly if condition still valid.
+    }
+  }
+
+  display_name = "Failed Revision Rollout: ${var.name}"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Failed Revision Rollout: ${var.name}"
+
+    condition_matched_log {
+      filter = <<EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name=${var.name}"
+        severity=ERROR
+        protoPayload.status.message:"Ready condition status changed to False"
+      EOT
+
+      label_extractors = {
+        "revision_name" = "EXTRACT(resource.labels.revision_name)"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+
+  enabled = "true"
+  project = var.project_id
+}
+
+
 // When the service is behind a load balancer, then it is publicly exposed and responsible
 // for handling its own authentication.
 resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthenticated" {


### PR DESCRIPTION
from the issue with `empty_dir` causing revision rollout to fail unnoticed.

