### PR TITLE
bug: fix missing quote for alert

### DIFF
--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -265,7 +265,7 @@ resource "google_monitoring_alert_policy" "bad-rollout" {
     condition_matched_log {
       filter = <<EOT
         resource.type="cloud_run_revision"
-        resource.labels.service_name=${var.name}"
+        resource.labels.service_name="${var.name}"
         severity=ERROR
         protoPayload.status.message:"Ready condition status changed to False"
       EOT


### PR DESCRIPTION
```
│ Error: Error creating AlertPolicy: googleapi: Error 400: Field alert_policy.conditions[0].filter had an invalid value of "        resource.type="cloud_run_revision"
│         resource.labels.service_name=nghia-cr-dev-api"
│         severity=ERROR
│         protoPayload.status.message:"Ready condition status changed to False"
│ ": Unparseable filter: syntax error at line 2, column 54, token '"
│         severity=ERROR
│         protoPayload.status.message:"'
│ 
│   with module.api.module.api-service.google_monitoring_alert_policy.bad-rollout,
│   on ../../../../terraform-infra-common/modules/regional-go-service/main.tf line 249, in resource "google_monitoring_alert_policy" "bad-rollout":
│  249: resource "google_monitoring_alert_policy" "bad-rollout" {
```