### PR TITLE
Change our attribute mapping to fit in character limits.

### DIFF
--- a/modules/github-gsa/main.tf
+++ b/modules/github-gsa/main.tf
@@ -25,7 +25,7 @@ locals {
     )
   )
   # Build up the "workflow" portion of the principal match regular expression.
-  workflowPart = (var.workflow_ref == "*") ? (
+  workflowPart = "${var.repository}/${(var.workflow_ref == "*") ? (
     (var.audit_workflow_ref != "") ? (
       var.audit_workflow_ref
       ) : (
@@ -34,13 +34,12 @@ locals {
     ) : (
     # TODO(mattmoor): How can we "quote" this?
     var.workflow_ref
-  )
+  )}"
   # TODO(mattmoor): How can we "quote" the `wif-pool` here?
-  principalSubject = "^principal://iam\\.googleapis\\.com/${var.wif-pool}/subject/${join("\\\\|", [
-    var.repository,
-    local.refPart,
+  principalSubject = "^(principal://iam\\.googleapis\\.com/${var.wif-pool}/subject/${join("[|]", [
     local.workflowPart,
-  ])}$"
+    local.refPart,
+  ])})$"
 
   exact = "attribute.exact/${join("|", [
     var.repository,

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -22,7 +22,9 @@ resource "google_iam_workload_identity_pool_provider" "this" {
     # Don't use the GitHub subject because it it less specific than ours, which also captures:
     #   - The pull request number via `refs/pulls/N/merge`, and
     #   - The worflow file.
-    "google.subject" = "assertion.repository + '|' + assertion.ref + '|' + assertion.workflow_ref.split('@')[0]"
+    # We don't include assertion.repository because it is redundant with the prefix on assertion.workflow_ref.
+    # We use assertion.ref instead of the ref included in workflow_ref so that we get the PR number on pull_request_target PRs.
+    "google.subject" = "assertion.workflow_ref.split('@')[0] + '|' + assertion.ref"
 
     # assertion.ref has one of the forms:
     #   - Branch: refs/heads/main


### PR DESCRIPTION
The `google.subject` claim is limited to 127 characters, which for certain repo names (e.g. `chainguard-dev/terraform-provider-chainguard`) is too small.

To mitigate this, we dump the repository name being explicitly separate and instead rely on the name that prefixes the `workflow_ref`.

There are a handful of additional changes here:
1. Switch to `[|]` for escaping the pipes, so they are not treated as disjunctions,
2. Wrap the inner regex in parenthesis, so `^(...)$` matches the hole string and the `|` characters don't mistakenly become disjunctions,
3. Include the (missing!) repository prefix in our GSA audit regular expression.

I tested this by modifying the existing secret alert policies to use this and it properly filters the authorized usage:
```
protoPayload.authenticationInfo.principalSubject=~"^(principal://iam\.googleapis\.com/projects/12758742386/locations/global/workloadIdentityPools/github-pool/subject/chainguard-dev/enterprise-packages[|]refs/heads/main[|]chainguard-dev/enterprise-packages/\.github/workflows/(build|withdraw-packages)\.yaml)$"
```

note: the above isn't what we expect the result of this PR to be, but it tests the new escaping, the parenthesis, and the addition of the repo to the workflow prefix.