### PR TITLE
regional-go-service: Only alert on failed revisions, not failed services

### DIFF
--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -268,6 +268,7 @@ resource "google_monitoring_alert_policy" "bad-rollout" {
         resource.labels.service_name="${var.name}"
         severity=ERROR
         protoPayload.status.message:"Ready condition status changed to False"
+        protoPayload.response.kind="Revision"
       EOT
 
       label_extractors = {


### PR DESCRIPTION
When a revision fails to rollout, 2 audit logs are triggered that look very similar. One is for the revision, one is for the service.

This condition seems to be targeting revisions, so filter on that kind.