### PR TITLE
Sidecar not to export traces

### DIFF
--- a/modules/otel-collector/cmd/otel-collector/kodata/config.yaml
+++ b/modules/otel-collector/cmd/otel-collector/kodata/config.yaml
@@ -1,9 +1,4 @@
 receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-
   prometheus:
     config:
       scrape_configs:
@@ -83,6 +78,6 @@ service:
   extensions: [health_check]
   pipelines:
     metrics:
-      receivers: [prometheus, otlp]
+      receivers: [prometheus]
       processors: [batch, memory_limiter, resourcedetection, resource]
       exporters: [googlemanagedprometheus]


### PR DESCRIPTION
Trace exports to sidecar doesn't work as expected and causing log spams. Turning it off for now.