### PR TITLE
httpmetrics: disable pprof endpoints

### DIFF
--- a/pkg/httpmetrics/metrics.go
+++ b/pkg/httpmetrics/metrics.go
@@ -3,10 +3,8 @@ package httpmetrics
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
-	"net/http/pprof"
 	"strconv"
 	"time"
 
@@ -40,22 +38,6 @@ func ServeMetrics() {
 		Addr:              fmt.Sprintf(":%d", env.MetricsPort),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	if env.EnablePprof {
-		// pprof handles
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
-		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
-		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
-		mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
-		log.Println("registering handle for /debug/pprof")
 	}
 
 	if err := srv.ListenAndServe(); err != nil {


### PR DESCRIPTION
Simply importing the package serves the endpoints. When the service is public, these endpoints are public, and that's Bad.

> To use pprof, link this package into your program:
> 
>     import _ "net/http/pprof"
