### PR TITLE
cloudevent recorder: optionally allow users to specify existing datas…

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -64,6 +64,45 @@ module "foo-emits-events" {
   ...
 }
 ```
+
+By default, the module will create a BigQuery dataset and table for each event type.
+
+To use an existing dataset, set `create_dataset` to `false` and provide the `dataset_id` of the existing dataset.
+
+Similarly, to use an existing table, set `types` to include `create_table` to false and the `table_id` of the existing table.
+
+```hcl
+module "foo-emits-events" {
+  source = "chainguard-dev/common/infra//modules/cloudevent-recorder"
+
+  name           = "my-recorder"
+  project_id     = var.project_id
+  regions        = module.networking.regional-networks
+  broker         = module.cloudevent-broker.broker
+  dataset_id     = var.dataset_id
+  create_dataset = false
+
+  retention-period = 30 // keep around 30 days worth of event data
+
+  provisioner = "user:sally@chainguard.dev"
+
+  types = {
+    "com.example.foo": {
+      schema = file("${path.module}/foo.schema.json")
+      notification_channels = local.notification_channels
+      table_id              = var.foo_table_name
+      create_table          = false
+    }
+    "com.example.bar": {
+      schema = file("${path.module}/bar.schema.json")
+      notification_channels = local.notification_channels
+      table_id              = var.bar_table_name
+      create_table          = false
+    }
+  }
+  notification_channels = local.notification_channels
+}
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -112,6 +151,7 @@ No requirements.
 | [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.trigger-suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [google_bigquery_dataset.existing](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/bigquery_dataset) | data source |
 | [google_client_openid_userinfo.me](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
@@ -123,6 +163,8 @@ No requirements.
 | <a name="input_broker"></a> [broker](#input\_broker) | A map from each of the input region names to the name of the Broker topic in that region. | `map(string)` | n/a | yes |
 | <a name="input_cloud_storage_config_max_bytes"></a> [cloud\_storage\_config\_max\_bytes](#input\_cloud\_storage\_config\_max\_bytes) | The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. | `number` | `1000000000` | no |
 | <a name="input_cloud_storage_config_max_duration"></a> [cloud\_storage\_config\_max\_duration](#input\_cloud\_storage\_config\_max\_duration) | The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. | `number` | `300` | no |
+| <a name="input_create_dataset"></a> [create\_dataset](#input\_create\_dataset) | Whether to create the BigQuery dataset. Set to false if the dataset already exists. | `bool` | `true` | no |
+| <a name="input_dataset_id"></a> [dataset\_id](#input\_dataset\_id) | The name of the BigQuery dataset to create. | `string` | `null` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on data resources. | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the BigQuery dataset in, and in which to run the data transfer jobs from GCS. | `string` | `"US"` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
@@ -135,7 +177,7 @@ No requirements.
 | <a name="input_provisioner"></a> [provisioner](#input\_provisioner) | The identity as which this module will be applied (so it may be granted permission to 'act as' the DTS service account).  This should be in the form expected by an IAM subject (e.g. user:sally@example.com) | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A recorder service and cloud storage bucket (into which the service writes events) will be created in each region. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 | <a name="input_retention-period"></a> [retention-period](#input\_retention-period) | The number of days to retain data in BigQuery. | `number` | n/a | yes |
-| <a name="input_types"></a> [types](#input\_types) | A map from cloudevent types to the BigQuery schema associated with them, as well as an alert threshold and a list of notification channels (for subscription-level issues). | <pre>map(object({<br>    schema                = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>    partition_field       = optional(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_types"></a> [types](#input\_types) | A map from cloudevent types to the BigQuery schema associated with them, as well as an alert threshold and a list of notification channels (for subscription-level issues). | <pre>map(object({<br>    schema                = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>    partition_field       = optional(string)<br>    table_id              = optional(string)<br>    create_table          = optional(bool, true)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/cloudevent-recorder/outputs.tf
+++ b/modules/cloudevent-recorder/outputs.tf
@@ -1,5 +1,5 @@
 output "dataset_id" {
-  value = google_bigquery_dataset.this.dataset_id
+  value = var.create_dataset ? google_bigquery_dataset.this[0].dataset_id : data.google_bigquery_dataset.existing[0].dataset_id
 }
 
 output "table_ids" {

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -96,6 +96,13 @@ module "triggers" {
   notification_channels = var.notification_channels
 }
 
+locals {
+  alerts = tomap({
+    for type, schema in var.types :
+    "BQ DTS ${var.name}-${type}" => lookup(google_monitoring_alert_policy.bq_dts, type, null) != null ? google_monitoring_alert_policy.bq_dts[type].id : null
+  })
+}
+
 module "recorder-dashboard" {
   source       = "../dashboard/cloudevent-receiver"
   service_name = var.name
@@ -105,7 +112,7 @@ module "recorder-dashboard" {
 
   notification_channels = var.notification_channels
 
-  alerts = tomap({ for type, schema in var.types : "BQ DTS ${var.name}-${type}" => google_monitoring_alert_policy.bq_dts[type].id })
+  alerts = local.alerts
 
   triggers = {
     for type, schema in var.types : "type: ${type}" => {

--- a/modules/cloudevent-recorder/subscriber-gcs.tf
+++ b/modules/cloudevent-recorder/subscriber-gcs.tf
@@ -23,7 +23,7 @@ resource "google_project_service_identity" "pubsub" {
 resource "google_pubsub_topic" "dead-letter" {
   for_each = var.method == "gcs" ? local.regional-types : {}
 
-  name     = "${var.name}-dlq-${substr(md5(each.key), 0, 6)}"
+  name = "${var.name}-dlq-${substr(md5(each.key), 0, 6)}"
 
   message_storage_policy {
     allowed_persistence_regions = [each.value.region]
@@ -45,7 +45,7 @@ resource "google_pubsub_subscription" "this" {
   for_each = var.method == "gcs" ? local.regional-types : {}
   name     = "${var.name}-${substr(md5(each.key), 0, 6)}"
 
-  topic    = var.broker[each.value.region]
+  topic = var.broker[each.value.region]
 
   ack_deadline_seconds = var.ack_deadline_seconds
 

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -52,6 +52,8 @@ variable "types" {
     alert_threshold       = optional(number, 50000)
     notification_channels = optional(list(string), [])
     partition_field       = optional(string)
+    table_id              = optional(string)
+    create_table          = optional(bool, true)
   }))
 }
 
@@ -99,4 +101,16 @@ variable "cloud_storage_config_max_duration" {
   description = "The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes."
   type        = number
   default     = 300 // default 5 minutes
+}
+
+variable "dataset_id" {
+  description = "The name of the BigQuery dataset to create."
+  type        = string
+  default     = null
+}
+
+variable "create_dataset" {
+  description = "Whether to create the BigQuery dataset. Set to false if the dataset already exists."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
…et and tables to record events into

This helps folks migrate to common infra modules who have existing datasets.

The existing behaviour are the defaults, i.e. without enabling the new create dataset and create table configs nothing will change.