### PR TITLE
cloudevent recorder, add configurable method of syncing events from a…

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -49,6 +49,21 @@ module "foo-emits-events" {
 }
 ```
 
+The default behavior of this module is to deploy a cloud event trigger that consumes events from a broker and uses log
+rotate to write them to a GCS bucket. The GCS bucket is then used as a source for a BigQuery Data Transfer Service job.
+
+To override this behavior, you can choose a different `method`.
+
+i.e. to use GCP native integration for pubsub to GCS:
+
+```hcl
+module "foo-emits-events" {
+  source = "chainguard-dev/common/infra//modules/cloudevent-recorder"
+  method = "gcs"
+
+  ...
+}
+```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -59,6 +74,7 @@ No requirements.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -74,21 +90,28 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [google-beta_google_project_service_identity.pubsub](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_bigquery_data_transfer_config.import-job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_data_transfer_config) | resource |
 | [google_bigquery_dataset.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
 | [google_bigquery_table.types](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) | resource |
 | [google_bigquery_table_iam_binding.import-writes-to-tables](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_binding) | resource |
 | [google_monitoring_alert_policy.bq_dts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.bucket-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription_iam_binding.allow-pubsub-to-ack](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
+| [google_pubsub_topic.dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_binding.allow-pubsub-to-send-to-dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
 | [google_service_account.import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.recorder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.bq-dts-assumes-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_iam_binding.provisioner-acts-as-import-identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_storage_bucket.recorder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_binding.broker-writes-to-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_iam_binding.import-reads-from-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_iam_binding.recorder-writes-to-gcs-buckets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.trigger-suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [google_client_openid_userinfo.me](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
@@ -96,9 +119,16 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ack_deadline_seconds"></a> [ack\_deadline\_seconds](#input\_ack\_deadline\_seconds) | The number of seconds to acknowledge a message before it is redelivered. | `number` | `300` | no |
 | <a name="input_broker"></a> [broker](#input\_broker) | A map from each of the input region names to the name of the Broker topic in that region. | `map(string)` | n/a | yes |
+| <a name="input_cloud_storage_config_max_bytes"></a> [cloud\_storage\_config\_max\_bytes](#input\_cloud\_storage\_config\_max\_bytes) | The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. | `number` | `1000000000` | no |
+| <a name="input_cloud_storage_config_max_duration"></a> [cloud\_storage\_config\_max\_duration](#input\_cloud\_storage\_config\_max\_duration) | The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. | `number` | `300` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on data resources. | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the BigQuery dataset in, and in which to run the data transfer jobs from GCS. | `string` | `"US"` | no |
+| <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
+| <a name="input_maximum_backoff"></a> [maximum\_backoff](#input\_maximum\_backoff) | The maximum delay between consecutive deliveries of a given message. | `number` | `600` | no |
+| <a name="input_method"></a> [method](#input\_method) | The method used to transfer events (e.g., trigger, gcs). | `string` | `"trigger"` | no |
+| <a name="input_minimum_backoff"></a> [minimum\_backoff](#input\_minimum\_backoff) | The minimum delay between consecutive deliveries of a given message. | `number` | `10` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert (for service-level issues). | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -13,7 +13,7 @@ resource "google_service_account" "recorder" {
 // The recorder service account is the only identity that should be writing
 // to the regional GCS buckets.
 resource "google_storage_bucket_iam_binding" "recorder-writes-to-gcs-buckets" {
-  for_each = var.regions
+  for_each = var.method == "trigger" ? var.regions : {}
 
   bucket  = google_storage_bucket.recorder[each.key].name
   role    = "roles/storage.admin"
@@ -21,6 +21,7 @@ resource "google_storage_bucket_iam_binding" "recorder-writes-to-gcs-buckets" {
 }
 
 module "this" {
+  count      = var.method == "trigger" ? 1 : 0
   source     = "../regional-go-service"
   project_id = var.project_id
   name       = var.name
@@ -77,7 +78,7 @@ resource "random_id" "trigger-suffix" {
 
 // Create a trigger for each region x type that sends events to the recorder service.
 module "triggers" {
-  for_each = local.regional-types
+  for_each = var.method == "trigger" ? local.regional-types : {}
 
   source = "../cloudevent-trigger"
 

--- a/modules/cloudevent-recorder/subscriber-gcs.tf
+++ b/modules/cloudevent-recorder/subscriber-gcs.tf
@@ -1,0 +1,83 @@
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+// If method is gcs, GCP subscription will write events directly to a GCS bucket.
+resource "google_storage_bucket_iam_binding" "broker-writes-to-gcs-buckets" {
+  for_each = var.method == "gcs" ? var.regions : {}
+
+  bucket  = google_storage_bucket.recorder[each.key].name
+  role    = "roles/storage.admin"
+  members = ["serviceAccount:${google_project_service_identity.pubsub.email}"]
+}
+
+// Lookup the identity of the pubsub service agent.
+resource "google_project_service_identity" "pubsub" {
+  provider = google-beta
+  project  = var.project_id
+  service  = "pubsub.googleapis.com"
+}
+
+resource "google_pubsub_topic" "dead-letter" {
+  for_each = var.method == "gcs" ? local.regional-types : {}
+
+  name     = "${var.name}-dlq-${substr(md5(each.key), 0, 6)}"
+
+  message_storage_policy {
+    allowed_persistence_regions = [each.value.region]
+  }
+}
+
+// Grant the pubsub service account the ability to send to the dead-letter topic.
+resource "google_pubsub_topic_iam_binding" "allow-pubsub-to-send-to-dead-letter" {
+  for_each = var.method == "gcs" ? local.regional-types : {}
+  topic    = google_pubsub_topic.dead-letter[each.key].name
+
+  role    = "roles/pubsub.publisher"
+  members = ["serviceAccount:${google_project_service_identity.pubsub.email}"]
+}
+
+// Configure the subscription to deliver the events matching our filter to this service
+// using the above identity to authorize the delivery..
+resource "google_pubsub_subscription" "this" {
+  for_each = var.method == "gcs" ? local.regional-types : {}
+  name     = "${var.name}-${substr(md5(each.key), 0, 6)}"
+
+  topic    = var.broker[each.value.region]
+
+  ack_deadline_seconds = var.ack_deadline_seconds
+
+  filter = "attributes.ce-type=\"${each.value.type}\""
+
+  cloud_storage_config {
+    bucket          = google_storage_bucket.recorder[each.value.region].name
+    filename_prefix = "${each.value.type}/"
+    max_bytes       = var.cloud_storage_config_max_bytes
+    max_duration    = "${var.cloud_storage_config_max_duration}s"
+  }
+
+  expiration_policy {
+    ttl = "" // This does not expire.
+  }
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.dead-letter[each.key].id
+    max_delivery_attempts = var.max_delivery_attempts
+  }
+
+  retry_policy {
+    minimum_backoff = "${var.minimum_backoff}s"
+    maximum_backoff = "${var.maximum_backoff}s"
+  }
+}
+
+// Grant the pubsub service account the ability to Acknowledge messages on this "this" subscription.
+resource "google_pubsub_subscription_iam_binding" "allow-pubsub-to-ack" {
+  for_each     = var.method == "gcs" ? local.regional-types : {}
+  subscription = google_pubsub_subscription.this[each.key].name
+
+  role    = "roles/pubsub.subscriber"
+  members = ["serviceAccount:${google_project_service_identity.pubsub.email}"]
+}

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -54,3 +54,49 @@ variable "types" {
     partition_field       = optional(string)
   }))
 }
+
+variable "method" { # todo (jr) add bq method that writes events directly to bq https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#example-usage---pubsub-subscription-push-bq
+  type        = string
+  description = "The method used to transfer events (e.g., trigger, gcs)."
+  default     = "trigger"
+  validation {
+    condition     = contains(["trigger", "gcs"], var.method)
+    error_message = "The environment must be one of: trigger or gcs."
+  }
+}
+
+variable "max_delivery_attempts" {
+  description = "The maximum number of delivery attempts for any event."
+  type        = number
+  default     = 5
+}
+
+variable "ack_deadline_seconds" {
+  description = "The number of seconds to acknowledge a message before it is redelivered."
+  type        = number
+  default     = 300
+}
+
+variable "minimum_backoff" {
+  description = "The minimum delay between consecutive deliveries of a given message."
+  type        = number
+  default     = 10
+}
+
+variable "maximum_backoff" {
+  description = "The maximum delay between consecutive deliveries of a given message."
+  type        = number
+  default     = 600
+}
+
+variable "cloud_storage_config_max_bytes" {
+  description = "The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB."
+  type        = number
+  default     = 1000000000 // default 1 GB
+}
+
+variable "cloud_storage_config_max_duration" {
+  description = "The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes."
+  type        = number
+  default     = 300 // default 5 minutes
+}


### PR DESCRIPTION
… broker

tl;dr specify a `method` tf var to override the default approach used to write broker events to a GCS bucket.

```
module "foo-emits-events" {
  source = "chainguard-dev/common/infra//modules/cloudevent-recorder"
  method = "gcs"

  ....
}
```

This keeps the default `method` of using cloudevent trigger and  regional go service + log rotate to conksume events from a broker and publish to a GCS bucket.

We add a configurable `method` that allows a user to select `gcs` today, this takes advantage of GCP native approach for a subscriber to write events directly into a GCS bucket, removing the need to run the cloud event trigger services above.  Docs on the [native subscription integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#example-usage---pubsub-subscription-push-cloudstorage).

Future additional method of `bq` can be explored which uses a [similar native integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#example-usage---pubsub-subscription-push-bq-table-schema).