### PR TITLE
bots: include receiver dashboard

### DIFF
--- a/modules/github-bots/README.md
+++ b/modules/github-bots/README.md
@@ -74,6 +74,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudevent-trigger"></a> [cloudevent-trigger](#module\_cloudevent-trigger) | chainguard-dev/common/infra//modules/cloudevent-trigger | n/a |
+| <a name="module_dashboard"></a> [dashboard](#module\_dashboard) | chainguard-dev/common/infra//modules/dashboard/cloudevent-receiver | n/a |
 | <a name="module_service"></a> [service](#module\_service) | chainguard-dev/common/infra//modules/regional-go-service | n/a |
 
 ## Resources

--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -81,7 +81,7 @@ module "cloudevent-trigger" {
   source   = "chainguard-dev/common/infra//modules/cloudevent-trigger"
 
   project_id = var.project_id
-  name       = "bot-trigger"
+  name       = "bot-trigger-${var.name}"
   broker     = var.broker[each.key]
   filter     = { "type" : var.github-event }
 
@@ -91,4 +91,19 @@ module "cloudevent-trigger" {
   }
 
   notification_channels = var.notification_channels
+}
+
+module "dashboard" {
+  source = "chainguard-dev/common/infra//modules/dashboard/cloudevent-receiver"
+
+  project_id   = var.project_id
+  service_name = var.name
+
+  triggers = {
+    (var.name) : {
+      subscription_prefix = "bot-trigger-${var.name}"
+    }
+  }
+
+  notification_channels = []
 }


### PR DESCRIPTION
Uniquely name the trigger so that the dashboard can only show that trigger's details.