### PR TITLE
optionally include GitHub metrics in dashboards

### DIFF
--- a/modules/dashboard/cloudevent-receiver/README.md
+++ b/modules/dashboard/cloudevent-receiver/README.md
@@ -84,6 +84,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_errgrp"></a> [errgrp](#module\_errgrp) | ../sections/errgrp | n/a |
+| <a name="module_github"></a> [github](#module\_github) | ../sections/github | n/a |
 | <a name="module_grpc"></a> [grpc](#module\_grpc) | ../sections/grpc | n/a |
 | <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
@@ -106,6 +107,7 @@ No requirements.
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
+| <a name="input_sections"></a> [sections](#input\_sections) | Sections to include in the dashboard | <pre>object({<br>    http   = optional(bool, true)  // Include HTTP section<br>    grpc   = optional(bool, true)  // Include GRPC section<br>    github = optional(bool, false) // Include GitHub API section<br>  })</pre> | <pre>{<br>  "github": false,<br>  "grpc": true,<br>  "http": true<br>}</pre> | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 | <a name="input_triggers"></a> [triggers](#input\_triggers) | A mapping from a descriptive name to a subscription name prefix, an alert threshold, and list of notification channels. | <pre>map(object({<br>    subscription_prefix   = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>  }))</pre> | n/a | yes |
 

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -36,6 +36,12 @@ module "grpc" {
   service_name = var.service_name
 }
 
+module "github" {
+  source = "../sections/github"
+  title  = "GitHub API"
+  filter = []
+}
+
 module "resources" {
   source        = "../sections/resources"
   title         = "Resources"
@@ -54,10 +60,11 @@ module "layout" {
     [
       module.errgrp.section,
       module.logs.section,
-      module.http.section,
-      module.grpc.section,
-      module.resources.section,
     ],
+    var.sections.http ? [module.http.section] : [],
+    var.sections.grpc ? [module.grpc.section] : [],
+    var.sections.github ? [module.github.section] : [],
+    [module.resources.section],
   )
 }
 

--- a/modules/dashboard/cloudevent-receiver/variables.tf
+++ b/modules/dashboard/cloudevent-receiver/variables.tf
@@ -32,3 +32,17 @@ variable "alerts" {
   type        = map(string)
   default     = {}
 }
+
+variable "sections" {
+  description = "Sections to include in the dashboard"
+  type = object({
+    http   = optional(bool, true)  // Include HTTP section
+    grpc   = optional(bool, true)  // Include GRPC section
+    github = optional(bool, false) // Include GitHub API section
+  })
+  default = {
+    http   = true
+    grpc   = true
+    github = false
+  }
+}

--- a/modules/dashboard/service/README.md
+++ b/modules/dashboard/service/README.md
@@ -63,6 +63,7 @@ No requirements.
 |------|--------|---------|
 | <a name="module_alerts"></a> [alerts](#module\_alerts) | ../sections/alerts | n/a |
 | <a name="module_errgrp"></a> [errgrp](#module\_errgrp) | ../sections/errgrp | n/a |
+| <a name="module_github"></a> [github](#module\_github) | ../sections/github | n/a |
 | <a name="module_grpc"></a> [grpc](#module\_grpc) | ../sections/grpc | n/a |
 | <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
@@ -84,6 +85,7 @@ No requirements.
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the dashboard. | `map` | `{}` | no |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
+| <a name="input_sections"></a> [sections](#input\_sections) | Sections to include in the dashboard | <pre>object({<br>    http   = optional(bool, true)  // Include HTTP section<br>    grpc   = optional(bool, true)  // Include GRPC section<br>    github = optional(bool, false) // Include GitHub API section<br>  })</pre> | <pre>{<br>  "github": false,<br>  "grpc": true,<br>  "http": true<br>}</pre> | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -25,6 +25,12 @@ module "grpc" {
   service_name = var.service_name
 }
 
+module "github" {
+  source = "../sections/github"
+  title  = "GitHub API"
+  filter = []
+}
+
 module "resources" {
   source                = "../sections/resources"
   title                 = "Resources"
@@ -50,10 +56,11 @@ module "layout" {
     [
       module.errgrp.section,
       module.logs.section,
-      module.http.section,
-      module.grpc.section,
-      module.resources.section,
-    ]
+    ],
+    var.sections.http ? [module.http.section] : [],
+    var.sections.grpc ? [module.grpc.section] : [],
+    var.sections.github ? [module.github.section] : [],
+    [module.resources.section],
   )
 }
 

--- a/modules/dashboard/service/variables.tf
+++ b/modules/dashboard/service/variables.tf
@@ -23,3 +23,17 @@ variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
 }
+
+variable "sections" {
+  description = "Sections to include in the dashboard"
+  type = object({
+    http   = optional(bool, true)  // Include HTTP section
+    grpc   = optional(bool, true)  // Include GRPC section
+    github = optional(bool, false) // Include GitHub API section
+  })
+  default = {
+    http   = true
+    grpc   = true
+    github = false
+  }
+}


### PR DESCRIPTION
This also makes it possible for callers to omit the HTTP or GRPC sections, e.g., if the service doesn't serve those.

The default behavior should match what we have today, but dashboards that would benefit from seeing GitHub API metrics can now have that.

GitHub API metrics aren't service-specific, so this graph might be misleading in some cases. At least showing it to people should make it easier to iterate on it.