### PR TITLE
use handlers for the gh bot

### DIFF
--- a/modules/github-bots/blocker/blocker.go
+++ b/modules/github-bots/blocker/blocker.go
@@ -15,66 +15,68 @@ import (
 //
 // This check can be made required so that blockers block merging of PRs.
 
-func New() sdk.Bot { return bot{} }
+func New() sdk.Bot {
+	name := "blocker"
 
-type bot struct{}
+	bot := sdk.NewBot(name)
+	bot.RegisterHandler(blockHandler(name))
 
-func (b bot) Name() string { return "blocker" }
+	return bot
+}
 
-func (b bot) OnPullRequest(ctx context.Context, pr *github.PullRequest) error {
-	log := clog.FromContext(ctx)
-	owner, repo := *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name
+func blockHandler(name string) sdk.PullRequestHandler {
+	return func(ctx context.Context, client sdk.GitHubClient, pr *github.PullRequest) error {
+		log := clog.FromContext(ctx)
+		owner, repo := *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name
 
-	hasBlockingLabel := slices.ContainsFunc(pr.Labels, func(l *github.Label) bool {
-		return strings.HasPrefix(*l.Name, "blocking/")
-	})
+		hasBlockingLabel := slices.ContainsFunc(pr.Labels, func(l *github.Label) bool {
+			return strings.HasPrefix(*l.Name, "blocking/")
+		})
 
-	client := sdk.NewGitHubClient(ctx, owner, repo, b.Name())
-	defer client.Close(ctx)
+		conclusion := "success"
+		if hasBlockingLabel {
+			conclusion = "failure"
+			log.Debug("PR %d has blocking label")
+		}
+		sha := *pr.Head.SHA
 
-	conclusion := "success"
-	if hasBlockingLabel {
-		conclusion = "failure"
-		log.Debug("PR %d has blocking label")
-	}
-	sha := *pr.Head.SHA
+		// If there are no check runs for the current head SHA, create one with the conclusion.
+		crs, _, err := client.Client().Checks.ListCheckRunsForRef(ctx, owner, repo, sha, &github.ListCheckRunsOptions{CheckName: github.String(name)})
+		if err != nil {
+			return fmt.Errorf("listing check runs: %w", err)
+		}
+		if len(crs.CheckRuns) == 0 {
+			log.Infof("Creating CheckRun for PR %d sha %s with conclusion %s", *pr.Number, sha, conclusion)
+			if _, _, err := client.Client().Checks.CreateCheckRun(ctx, owner, repo, github.CreateCheckRunOptions{
+				// Name:       b.Name,
+				HeadSHA:    sha,
+				Status:     github.String("completed"),
+				Conclusion: &conclusion,
+			}); err != nil {
+				return fmt.Errorf("creating check run: %w", err)
+			}
+			return nil
+		}
 
-	// If there are no check runs for the current head SHA, create one with the conclusion.
-	crs, _, err := client.Client().Checks.ListCheckRunsForRef(ctx, owner, repo, sha, &github.ListCheckRunsOptions{CheckName: github.String(b.Name())})
-	if err != nil {
-		return fmt.Errorf("listing check runs: %w", err)
-	}
-	if len(crs.CheckRuns) == 0 {
-		log.Infof("Creating CheckRun for PR %d sha %s with conclusion %s", *pr.Number, sha, conclusion)
-		if _, _, err := client.Client().Checks.CreateCheckRun(ctx, owner, repo, github.CreateCheckRunOptions{
-			Name:       b.Name(),
-			HeadSHA:    sha,
+		// No change, nothing else to do.
+		if *crs.CheckRuns[0].Conclusion == conclusion {
+			log.Debugf("CheckRun for PR %d sha %s already has conclusion %s", *pr.Number, sha, conclusion)
+			return nil
+		}
+
+		// If there's already a check run, update its conclusion.
+		log.Infof("Updating CheckRun for PR %d sha %s with conclusion %s", *pr.Number, sha, conclusion)
+		if _, _, err = client.Client().Checks.UpdateCheckRun(ctx, owner, repo, *crs.CheckRuns[0].ID, github.UpdateCheckRunOptions{
+			Name:       name,
 			Status:     github.String("completed"),
 			Conclusion: &conclusion,
+			Output: &github.CheckRunOutput{
+				Title:   github.String("Blocking label check"),
+				Summary: github.String("This PR has a blocking label"),
+			},
 		}); err != nil {
-			return fmt.Errorf("creating check run: %w", err)
+			return fmt.Errorf("updating check run %d: %w", *crs.CheckRuns[0].ID, err)
 		}
 		return nil
 	}
-
-	// No change, nothing else to do.
-	if *crs.CheckRuns[0].Conclusion == conclusion {
-		log.Debugf("CheckRun for PR %d sha %s already has conclusion %s", *pr.Number, sha, conclusion)
-		return nil
-	}
-
-	// If there's already a check run, update its conclusion.
-	log.Infof("Updating CheckRun for PR %d sha %s with conclusion %s", *pr.Number, sha, conclusion)
-	if _, _, err = client.Client().Checks.UpdateCheckRun(ctx, owner, repo, *crs.CheckRuns[0].ID, github.UpdateCheckRunOptions{
-		Name:       b.Name(),
-		Status:     github.String("completed"),
-		Conclusion: &conclusion,
-		Output: &github.CheckRunOutput{
-			Title:   github.String("Blocking label check"),
-			Summary: github.String("This PR has a blocking label"),
-		},
-	}); err != nil {
-		return fmt.Errorf("updating check run %d: %w", *crs.CheckRuns[0].ID, err)
-	}
-	return nil
 }

--- a/modules/github-bots/blocker/main.go
+++ b/modules/github-bots/blocker/main.go
@@ -1,5 +1,13 @@
 package main
 
-import "github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+import (
+	"log"
 
-func main() { sdk.Serve(New()) }
+	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+)
+
+func main() {
+	if err := sdk.Serve(New()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/modules/github-bots/blocker/main.go
+++ b/modules/github-bots/blocker/main.go
@@ -1,13 +1,7 @@
 package main
 
 import (
-	"log"
-
 	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
 )
 
-func main() {
-	if err := sdk.Serve(New()); err != nil {
-		log.Fatal(err)
-	}
-}
+func main() { sdk.Serve(New()) }

--- a/modules/github-bots/dnm/dnm.go
+++ b/modules/github-bots/dnm/dnm.go
@@ -8,27 +8,27 @@ import (
 	"github.com/google/go-github/v61/github"
 )
 
-type bot struct{}
+func New() sdk.Bot {
+	name := "dnm"
 
-func New() sdk.Bot { return bot{} }
+	bot := sdk.NewBot(name)
+	bot.RegisterHandler(dnmHandler())
+
+	return bot
+}
 
 const label = "blocking/dnm"
 
-func (b bot) Name() string { return "dnm" }
-
-func (b bot) OnPullRequest(ctx context.Context, pr *github.PullRequest) error {
-	owner, repo := *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name
-
-	client := sdk.NewGitHubClient(ctx, owner, repo, b.Name())
-	defer client.Close(ctx)
-
-	// If the title contains some variant of "dnm" and the PR doesn't have the label, add it -- this will no-op if it already has it.
-	for _, dnm := range []string{"dnm", "do not merge", "donotmerge", "do-not-merge"} {
-		if strings.Contains(strings.ToLower(*pr.Title), dnm) {
-			return client.AddLabel(ctx, pr, label)
+func dnmHandler() sdk.PullRequestHandler {
+	return func(ctx context.Context, client sdk.GitHubClient, pr *github.PullRequest) error {
+		// If the title contains some variant of "dnm" and the PR doesn't have the label, add it -- this will no-op if it already has it.
+		for _, dnm := range []string{"dnm", "do not merge", "donotmerge", "do-not-merge"} {
+			if strings.Contains(strings.ToLower(*pr.Title), dnm) {
+				return client.AddLabel(ctx, pr, label)
+			}
 		}
-	}
 
-	// If it has the label and the title doesn't match, remove the label -- this will no-op if it already doesn't have it.
-	return client.RemoveLabel(ctx, pr, label)
+		// If it has the label and the title doesn't match, remove the label -- this will no-op if it already doesn't have it.
+		return client.RemoveLabel(ctx, pr, label)
+	}
 }

--- a/modules/github-bots/dnm/main.go
+++ b/modules/github-bots/dnm/main.go
@@ -1,5 +1,13 @@
 package main
 
-import "github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+import (
+	"log"
 
-func main() { sdk.Serve(New()) }
+	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+)
+
+func main() {
+	if err := sdk.Serve(New()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/modules/github-bots/dnm/main.go
+++ b/modules/github-bots/dnm/main.go
@@ -1,13 +1,7 @@
 package main
 
 import (
-	"log"
-
 	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
 )
 
-func main() {
-	if err := sdk.Serve(New()); err != nil {
-		log.Fatal(err)
-	}
-}
+func main() { sdk.Serve(New()) }

--- a/modules/github-bots/sdk/handlers.go
+++ b/modules/github-bots/sdk/handlers.go
@@ -10,13 +10,13 @@ type EventHandlerFunc interface {
 	EventType() EventType
 }
 
-type PullRequestHandler func(ctx context.Context, client GitHubClient, pr *github.PullRequest) error
+type PullRequestHandler func(ctx context.Context, pre github.PullRequestEvent, pr *github.PullRequest) error
 
 func (r PullRequestHandler) EventType() EventType {
 	return PullRequestEvent
 }
 
-type WorkflowRunHandler func(ctx context.Context, client GitHubClient, wr *github.WorkflowRun) error
+type WorkflowRunHandler func(ctx context.Context, wre github.WorkflowRunEvent, wr *github.WorkflowRun) error
 
 func (r WorkflowRunHandler) EventType() EventType {
 	return WorkflowRunEvent

--- a/modules/github-bots/sdk/handlers.go
+++ b/modules/github-bots/sdk/handlers.go
@@ -1,0 +1,30 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/google/go-github/v61/github"
+)
+
+type EventHandlerFunc interface {
+	EventType() EventType
+}
+
+type PullRequestHandler func(ctx context.Context, client GitHubClient, pr *github.PullRequest) error
+
+func (r PullRequestHandler) EventType() EventType {
+	return PullRequestEvent
+}
+
+type WorkflowRunHandler func(ctx context.Context, client GitHubClient, wr *github.WorkflowRun) error
+
+func (r WorkflowRunHandler) EventType() EventType {
+	return WorkflowRunEvent
+}
+
+type EventType string
+
+const (
+	PullRequestEvent EventType = "dev.chainguard.github.pull_request"
+	WorkflowRunEvent EventType = "dev.chainguard.github.workflow_run"
+)

--- a/modules/github-bots/time/main.go
+++ b/modules/github-bots/time/main.go
@@ -1,5 +1,13 @@
 package main
 
-import "github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+import (
+	"log"
 
-func main() { sdk.Serve(New()) }
+	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
+)
+
+func main() {
+	if err := sdk.Serve(New()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/modules/github-bots/time/main.go
+++ b/modules/github-bots/time/main.go
@@ -1,13 +1,7 @@
 package main
 
 import (
-	"log"
-
 	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
 )
 
-func main() {
-	if err := sdk.Serve(New()); err != nil {
-		log.Fatal(err)
-	}
-}
+func main() { sdk.Serve(New()) }

--- a/modules/github-bots/time/time.go
+++ b/modules/github-bots/time/time.go
@@ -9,17 +9,17 @@ import (
 	"github.com/google/go-github/v61/github"
 )
 
-type bot struct{}
+func New() sdk.Bot {
+	name := "time"
 
-func New() sdk.Bot { return bot{} }
+	bot := sdk.NewBot(name)
+	bot.RegisterHandler(timeHandler(name))
 
-func (b bot) Name() string { return "time" }
+	return bot
+}
 
-func (b bot) OnPullRequest(ctx context.Context, pr *github.PullRequest) error {
-	owner, repo := *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name
-
-	client := sdk.NewGitHubClient(ctx, owner, repo, b.Name())
-	defer client.Close(ctx)
-
-	return client.SetComment(ctx, pr, b.Name(), fmt.Sprintf("The time is now %s", time.Now().Format(time.RFC3339)))
+func timeHandler(name string) sdk.PullRequestHandler {
+	return func(ctx context.Context, client sdk.GitHubClient, pr *github.PullRequest) error {
+		return client.SetComment(ctx, pr, name, fmt.Sprintf("The time is now %s", time.Now().Format(time.RFC3339)))
+	}
 }


### PR DESCRIPTION
refactors the bot to use `Handlers` that get explicitly registered in place of the implicit interfaces.

this doesn't solve the `event` -> `*github` serialization, but makes the creation of bots and their associated functions a little more ergonomic.

this also adds a case for the `workflow_run` event, and hoists the serialization out into a function until we can tackle this with codegen