### PR TITLE
cloudevent-recorder: ignore unknown values

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -136,6 +136,7 @@ No requirements.
 | <a name="input_cloud_storage_config_max_bytes"></a> [cloud\_storage\_config\_max\_bytes](#input\_cloud\_storage\_config\_max\_bytes) | The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. | `number` | `1000000000` | no |
 | <a name="input_cloud_storage_config_max_duration"></a> [cloud\_storage\_config\_max\_duration](#input\_cloud\_storage\_config\_max\_duration) | The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. | `number` | `300` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on data resources. | `bool` | `true` | no |
+| <a name="input_ignore_unknown_values"></a> [ignore\_unknown\_values](#input\_ignore\_unknown\_values) | Whether to ignore unknown values in the data, when transferring data to BigQuery. | `bool` | `false` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the BigQuery dataset in, and in which to run the data transfer jobs from GCS. | `string` | `"US"` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
 | <a name="input_maximum_backoff"></a> [maximum\_backoff](#input\_maximum\_backoff) | The maximum delay between consecutive deliveries of a given message. | `number` | `600` | no |

--- a/modules/cloudevent-recorder/bigquery.tf
+++ b/modules/cloudevent-recorder/bigquery.tf
@@ -112,7 +112,7 @@ resource "google_bigquery_data_transfer_config" "import-job" {
     file_format                     = "JSON"
     max_bad_records                 = 0
     delete_source_files             = false
-    ignore_unknown_values           = true
+    ignore_unknown_values           = var.ignore_unknown_values
   }
 }
 

--- a/modules/cloudevent-recorder/bigquery.tf
+++ b/modules/cloudevent-recorder/bigquery.tf
@@ -112,6 +112,7 @@ resource "google_bigquery_data_transfer_config" "import-job" {
     file_format                     = "JSON"
     max_bad_records                 = 0
     delete_source_files             = false
+    ignore_unknown_values           = true
   }
 }
 

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -100,3 +100,9 @@ variable "cloud_storage_config_max_duration" {
   type        = number
   default     = 300 // default 5 minutes
 }
+
+variable "ignore_unknown_values" {
+  description = "Whether to ignore unknown values in the data, when transferring data to BigQuery."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
From this page: https://cloud.google.com/bigquery/docs/cloud-storage-transfer#bq

<img width="740" alt="Screenshot 2024-04-16 at 1 20 11 PM" src="https://github.com/chainguard-dev/terraform-infra-common/assets/210737/21cc2eef-87a3-4a6e-bf99-82656b3f785e">

If this works as documented, we can avoid pre-filtering GH event payloads before they enter the broker, and rely on DTS to drop fields outside our schema all the way "to the right".

We could then make our BQ schemas more of an implementation detail, and internal to schemagen, and GH event subscribers could get the full GH event payload whether or not the fields end up getting recorded.