### PR TITLE
Automatically populate `ce-actor` in our ingress service.

### DIFF
--- a/modules/cloudevent-broker/cmd/ingress/main.go
+++ b/modules/cloudevent-broker/cmd/ingress/main.go
@@ -7,13 +7,16 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/kelseyhightower/envconfig"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
@@ -23,6 +26,7 @@ import (
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	cgpubsub "github.com/chainguard-dev/terraform-infra-common/pkg/pubsub"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
 const (
@@ -52,6 +56,15 @@ func main() {
 		clog.Fatalf("failed to create CE client, %v", err)
 	}
 
+	provider, err := oidc.NewProvider(ctx, "https://accounts.google.com")
+	if err != nil {
+		clog.Fatalf("failed to create OIDC provider, %v", err)
+	}
+	verifier := provider.Verifier(&oidc.Config{
+		// When on Cloud Run, this is checked by the platform.
+		SkipClientIDCheck: true,
+	})
+
 	projectID, err := metadata.ProjectID()
 	if err != nil {
 		clog.Fatalf("failed to get project ID, %v", err)
@@ -64,11 +77,40 @@ func main() {
 	topic := psc.Topic(env.Topic)
 	defer topic.Stop()
 
-	if err := c.StartReceiver(cloudevents.ContextWithRetriesExponentialBackoff(ctx, retryDelay, maxRetry), func(ctx context.Context, event cloudevents.Event) {
-		res := topic.Publish(ctx, cgpubsub.FromCloudEvent(ctx, event))
+	if err := c.StartReceiver(cloudevents.ContextWithRetriesExponentialBackoff(ctx, retryDelay, maxRetry), func(ctx context.Context, event cloudevents.Event) error {
+		// We expect Chainguard webhooks to pass an Authorization header.
+		auth := strings.TrimPrefix(cehttp.RequestDataFromContext(ctx).Header.Get("Authorization"), "Bearer ")
+		if auth == "" {
+			return cloudevents.NewHTTPResult(http.StatusUnauthorized, "Unauthorized")
+		}
+		tok, err := verifier.Verify(ctx, auth)
+		if err != nil {
+			clog.FromContext(ctx).Errorf("failed to verify Authorization: %v", err)
+			return cloudevents.NewHTTPResult(http.StatusUnauthorized, err.Error())
+		}
+		var claims struct {
+			Email         string `json:"email"`
+			EmailVerified bool   `json:"email_verified"`
+		}
+		if err := tok.Claims(&claims); err != nil {
+			clog.FromContext(ctx).Errorf("failed to extract email claims: %v", err)
+			return cloudevents.NewHTTPResult(http.StatusUnauthorized, err.Error())
+		}
+		if !claims.EmailVerified {
+			clog.FromContext(ctx).Errorf("email claim is not verified: %s", claims.Email)
+			return cloudevents.NewHTTPResult(http.StatusUnauthorized, "Unverified email claim")
+		}
+		msg := cgpubsub.FromCloudEvent(ctx, event)
+		// Turn the email of the Google Service Account that sent the cloud
+		// event into an "actor" extension on the cloud event.
+		msg.Attributes["ce-actor"] = claims.Email
+
+		res := topic.Publish(ctx, msg)
 		if _, err := res.Get(ctx); err != nil {
 			clog.FromContext(ctx).Errorf("failed to forward event: %v\n%v", event, err)
+			return cloudevents.NewHTTPResult(http.StatusInternalServerError, err.Error())
 		}
+		return nil
 	}); err != nil {
 		clog.Fatalf("failed to start receiver, %v", err)
 	}


### PR DESCRIPTION
This tracks the (Google-)verified identity that was used to send the event.