### PR TITLE
make resource limits configurable for broker and recorder

### DIFF
--- a/modules/cloudevent-broker/README.md
+++ b/modules/cloudevent-broker/README.md
@@ -106,6 +106,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_limits"></a> [limits](#input\_limits) | Resource limits for the regional go service. | <pre>object({<br>    cpu    = string<br>    memory = string<br>  })</pre> | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -42,6 +42,9 @@ module "this" {
         name  = "PUBSUB_TOPIC"
         value = { for k, v in google_pubsub_topic.this : k => v.name }
       }]
+      resources = {
+        limits = var.limits
+      }
     }
   }
 

--- a/modules/cloudevent-broker/variables.tf
+++ b/modules/cloudevent-broker/variables.tf
@@ -18,3 +18,12 @@ variable "notification_channels" {
   description = "List of notification channels to alert."
   type        = list(string)
 }
+
+variable "limits" {
+  description = "Resource limits for the regional go service."
+  type = object({
+    cpu    = string
+    memory = string
+  })
+  default = null
+}

--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -137,6 +137,7 @@ No requirements.
 | <a name="input_cloud_storage_config_max_duration"></a> [cloud\_storage\_config\_max\_duration](#input\_cloud\_storage\_config\_max\_duration) | The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. | `number` | `300` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on data resources. | `bool` | `true` | no |
 | <a name="input_ignore_unknown_values"></a> [ignore\_unknown\_values](#input\_ignore\_unknown\_values) | Whether to ignore unknown values in the data, when transferring data to BigQuery. | `bool` | `false` | no |
+| <a name="input_limits"></a> [limits](#input\_limits) | Resource limits for the regional go service. | <pre>object({<br>    cpu    = string<br>    memory = string<br>  })</pre> | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to create the BigQuery dataset in, and in which to run the data transfer jobs from GCS. | `string` | `"US"` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any event. | `number` | `5` | no |
 | <a name="input_maximum_backoff"></a> [maximum\_backoff](#input\_maximum\_backoff) | The maximum delay between consecutive deliveries of a given message. | `number` | `600` | no |

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -44,10 +44,7 @@ module "this" {
         mount_path = "/logs"
       }]
       resources = {
-        limits = {
-          cpu    = "1.0"
-          memory = "1.5Gi"
-        }
+        limits = var.limits
       }
     }
     "logrotate" = {

--- a/modules/cloudevent-recorder/subscriber-gcs.tf
+++ b/modules/cloudevent-recorder/subscriber-gcs.tf
@@ -23,7 +23,7 @@ resource "google_project_service_identity" "pubsub" {
 resource "google_pubsub_topic" "dead-letter" {
   for_each = var.method == "gcs" ? local.regional-types : {}
 
-  name     = "${var.name}-dlq-${substr(md5(each.key), 0, 6)}"
+  name = "${var.name}-dlq-${substr(md5(each.key), 0, 6)}"
 
   message_storage_policy {
     allowed_persistence_regions = [each.value.region]
@@ -45,7 +45,7 @@ resource "google_pubsub_subscription" "this" {
   for_each = var.method == "gcs" ? local.regional-types : {}
   name     = "${var.name}-${substr(md5(each.key), 0, 6)}"
 
-  topic    = var.broker[each.value.region]
+  topic = var.broker[each.value.region]
 
   ack_deadline_seconds = var.ack_deadline_seconds
 

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -106,3 +106,12 @@ variable "ignore_unknown_values" {
   type        = bool
   default     = false
 }
+
+variable "limits" {
+  description = "Resource limits for the regional go service."
+  type = object({
+    cpu    = string
+    memory = string
+  })
+  default = null
+}


### PR DESCRIPTION
pass down the limits clause to `regional-go-service` so the user of the `broker` and `recorder` can set resource limits appropriately.

this reverts a previous change to increase the memory for recorder statically.


