### PR TITLE
Add dejavu-bq as recorder cmd

### DIFF
--- a/modules/cloudevent-recorder/cmd/dejavu-bq/README.md
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/README.md
@@ -1,0 +1,45 @@
+# `dejavu-bq`
+
+_"Wait.. haven't I seen this data before? ..."_
+
+`dejavu-bq` is a small replay binary that aims to assist quick development of
+bots to add to our bot army. The goal is to have something that queries bigquery
+and converts rows into cloudevents a local bot can consume.
+
+Right now in order to quickly prototype a bot, you have to stand up an obscene
+amount of backing infrastructure. This small cli lets you simply plug into any
+database you have access to and scrape rows and convert them to cloudevents to
+start prototyping on prod data without touching a line of terraform.
+
+It's extremely rough right now but acts as a POC of how we could do it. Please
+add and make it better!
+
+### Usage
+
+```bash
+PROJECT=prod-images-c6e5 \
+    QUERY='SELECT * FROM `cloudevents_ghe_prod_rec.dev_chainguard_github_workflow_run` WHERE TIMESTAMP_TRUNC(_PARTITIONTIME, DAY) = TIMESTAMP("2024-04-18") LIMIT 5' \
+    EVENT_TYPE='dev.chainguard.github.workflow_run' \
+    ./dejavu-bq
+```
+
+### Developing a bot locally
+
+The major drive behind this utility is to speed up building a bot. You can build
+and run a bot locally bypassing the octosts token exchange
+
+```bash
+cd ~/path/to/my/bot
+
+GITHUB_TOKEN=$(gh auth token) go run .
+```
+
+Now try using an octosts policy with the following command.
+
+```bash
+cd ~/path/to/my/bot
+
+GITHUB_TOKEN=$(chainctl auth octo-sts --scope chainguard-dev/fake-repo --identity mybot) go run .
+```
+
+**NOTE:** I haven't gotten this working yet, not sure what's wrong but in theory it works

--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -43,13 +43,13 @@ func Publish(ctx context.Context, env envConfig, event cloudevents.Event) error 
 		cloudevents.WithTarget(fmt.Sprintf("%s:%d", env.Host, env.Port)),
 		cehttp.WithClient(http.Client{}))
 	if err != nil {
-		return fmt.Errorf("failed to create cloudevents client: %v", err)
+		return fmt.Errorf("failed to create cloudevents client: %w", err)
 	}
 
 	rctx := cloudevents.ContextWithRetriesExponentialBackoff(context.WithoutCancel(ctx), retryDelay, maxRetry)
 	ceresult := ceclient.Send(rctx, event)
 	if cloudevents.IsUndelivered(ceresult) || cloudevents.IsNACK(ceresult) {
-		return fmt.Errorf("Failed to deliver event: %v", ceresult)
+		return fmt.Errorf("failed to deliver event: %w", ceresult)
 	}
 
 	return nil

--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -59,7 +59,7 @@ func main() {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
 		clog.Errorf("failed to process env var: %s", err)
-        return
+		return
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -73,7 +73,7 @@ func main() {
 	client, err := bigquery.NewClient(ctx, env.Project)
 	if err != nil {
 		log.Errorf("failed to create bigquery client: %v", err)
-        return
+		return
 	}
 	defer client.Close()
 
@@ -82,7 +82,7 @@ func main() {
 	if err != nil {
 		log.Error(env.Query)
 		log.Errorf("failed to run thresholdQuery, %v", err)
-        return
+		return
 	}
 
 	// Iterate through each row in the returned query and handle every module
@@ -102,7 +102,7 @@ func main() {
 		body, err := json.Marshal(row)
 		if err != nil {
 			log.Errorf("marshaling row: %v", err)
-            return
+			return
 		}
 		log.Info(string(body))
 
@@ -115,14 +115,14 @@ func main() {
 		event.SetSource(env.EventSource)
 		if err := event.SetData(cloudevents.ApplicationJSON, body); err != nil {
 			log.Errorf("failed to set data: %v", err)
-            return
+			return
 		}
 
 		// TODO: Time based publishing if we care about replaying using the
 		// timestamps in the dataset
-        if err := Publish(ctx, env, event); err != nil {
-            log.Errorf("Publishing event: %v", err)
-            // Try to process next events
-        }
+		if err := Publish(ctx, env, event); err != nil {
+			log.Errorf("Publishing event: %v", err)
+			// Try to process next events
+		}
 	}
 }

--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/chainguard-dev/clog"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/kelseyhightower/envconfig"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	retryDelay = 10 * time.Millisecond
+	maxRetry   = 3
+)
+
+type envConfig struct {
+	Host string `envconfig:"HOST" default:"http://0.0.0.0" required:"true"`
+	Port int    `envconfig:"PORT" default:"8080" required:"true"`
+
+	EventType   string `envconfig:"EVENT_TYPE" default:"dev.chainguard.not_specified.not_specified" required:"true"`
+	EventSource string `envconfig:"EVENT_SOURCE" default:"github.com" required:"true"`
+
+	// Project is the GCP project where the dataset lives
+	Project string `envconfig:"PROJECT" required:"true"`
+
+	// QueryWindow is the window to look for release failures
+	Query string `envconfig:"QUERY" required:"true"`
+}
+
+func Publish(ctx context.Context, env envConfig, event cloudevents.Event) error {
+	log := clog.FromContext(ctx)
+
+	// TODO: Add idtoken back?
+	ceclient, err := cloudevents.NewClientHTTP(
+		cloudevents.WithTarget(fmt.Sprintf("%s:%d", env.Host, env.Port)),
+		cehttp.WithClient(http.Client{}))
+	if err != nil {
+		log.Fatalf("failed to create cloudevents client: %v", err)
+	}
+
+	rctx := cloudevents.ContextWithRetriesExponentialBackoff(context.WithoutCancel(ctx), retryDelay, maxRetry)
+	ceresult := ceclient.Send(rctx, event)
+	if cloudevents.IsUndelivered(ceresult) || cloudevents.IsNACK(ceresult) {
+		log.Errorf("Failed to deliver event: %v", ceresult)
+	}
+
+	return nil
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		clog.Fatalf("failed to process env var: %s", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	log := clog.FromContext(ctx)
+
+	// TODO: Cache older queries, presumably a use case is replaying the same
+	// data over and over so we can cache it so we avoid hitting bq every time
+
+	// BigQuery client
+	client, err := bigquery.NewClient(ctx, env.Project)
+	if err != nil {
+		log.Fatalf("failed to create bigquery client: %v", err)
+	}
+	defer client.Close()
+
+	q := client.Query(env.Query)
+	it, err := q.Read(ctx)
+	if err != nil {
+		log.Error(env.Query)
+		log.Fatalf("failed to run thresholdQuery, %v", err)
+	}
+
+	// Iterate through each row in the returned query and handle every module
+	// that is above the failure threshold.
+	for {
+		var row map[string]bigquery.Value
+		err = it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Errorf("failed to read row, %v", err)
+		}
+
+		log.Infof("%+v\n", row)
+
+		body, err := json.Marshal(row)
+		if err != nil {
+			log.Fatalf("marshaling row: %v", err)
+		}
+		log.Info(string(body))
+
+		// TODO: Extract event type
+		log = log.With("event-type", env.EventType)
+		log.Debugf("forwarding event: %s", env.EventType)
+
+		event := cloudevents.NewEvent()
+		event.SetType(env.EventType)
+		event.SetSource(env.EventSource)
+		if err := event.SetData(cloudevents.ApplicationJSON, body); err != nil {
+			log.Fatalf("failed to set data: %v", err)
+		}
+
+		// TODO: Time based publishing if we care about replaying using the
+		// timestamps in the dataset
+		Publish(ctx, env, event)
+	}
+}


### PR DESCRIPTION
Add [dejavu-bq](https://github.com/chainguard-dev/dejavu-bq) to the recorder as a replay utility. This should replay any bigquery data returned from the specified query as cloudevents.