### PR TITLE
pull in pprof, but reset DefaultServeMux to not register pprof by default

### DIFF
--- a/pkg/httpmetrics/metrics.go
+++ b/pkg/httpmetrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -34,12 +35,29 @@ func ServeMetrics() {
 		slog.Error("Failed to process environment variables", "error", err)
 		return
 	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", env.MetricsPort),
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	if env.EnablePprof {
+		// pprof handles
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+		mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+		mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+		mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		slog.Info("registering handle for /debug/pprof")
 	}
 
 	if err := srv.ListenAndServe(); err != nil {
@@ -92,6 +110,8 @@ func init() {
 	if err := envconfig.Process("", &env); err != nil {
 		slog.Warn("Failed to process environment variables", "error", err)
 	}
+	// Reset default serve mux to remove pprof registration
+	http.DefaultServeMux = http.NewServeMux()
 }
 
 // Handler wraps a given http handler in standard metrics handlers.


### PR DESCRIPTION
this change adds back pprof.
as part of this lib, we reset the default serve mux in `init()` to remove the pprof handler registration so it is not exposed by default.

https://github.com/golang/go/issues/42834#issuecomment-1752610216
https://gist.github.com/sudo-suhas/9cd7fae904b94f93730843b118729230#access-control