### PR TITLE
allow cloud profiler to be used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	chainguard.dev/sdk v0.1.19
 	cloud.google.com/go/bigquery v1.60.0
 	cloud.google.com/go/compute/metadata v0.3.0
+	cloud.google.com/go/profiler v0.4.0
 	cloud.google.com/go/pubsub v1.37.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.22.0
 	github.com/chainguard-dev/clog v1.3.1
@@ -54,6 +55,7 @@ require (
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ cloud.google.com/go/longrunning v0.5.6 h1:xAe8+0YaWoCKr9t1+aWe+OeQgN/iJK1fEgZSXm
 cloud.google.com/go/longrunning v0.5.6/go.mod h1:vUaDrWYOMKRuhiv6JBnn49YxCPz2Ayn9GqyjaBT8/mA=
 cloud.google.com/go/monitoring v1.18.0 h1:NfkDLQDG2UR3WYZVQE8kwSbUIEyIqJUPl+aOQdFH1T4=
 cloud.google.com/go/monitoring v1.18.0/go.mod h1:c92vVBCeq/OB4Ioyo+NbN2U7tlg5ZH41PZcdvfc+Lcg=
+cloud.google.com/go/profiler v0.4.0 h1:ZeRDZbsOBDyRG0OiK0Op1/XWZ3xeLwJc9zjkzczUxyY=
+cloud.google.com/go/profiler v0.4.0/go.mod h1:RvPlm4dilIr3oJtAOeFQU9Lrt5RoySHSDj4pTd6TWeU=
 cloud.google.com/go/pubsub v1.37.0 h1:0uEEfaB1VIJzabPpwpZf44zWAKAme3zwKKxHk7vJQxQ=
 cloud.google.com/go/pubsub v1.37.0/go.mod h1:YQOQr1uiUM092EXwKs56OPT650nwnawc+8/IjoUeGzQ=
 cloud.google.com/go/storage v1.39.1 h1:MvraqHKhogCOTXTlct/9C3K3+Uy2jBmFYb3/Sp6dVtY=
@@ -131,6 +133,8 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -170,6 +174,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
 github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
+github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 h1:hR7/MlvK23p6+lIw9SN1TigNLn9ZnF3W4SYRKq2gAHs=
+github.com/google/pprof v0.0.0-20230602150820-91b7bce49751/go.mod h1:Jh3hGz2jkYak8qXPD19ryItVnUgpgeqzdkY/D0EaeuA=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=

--- a/modules/cloudevent-broker/cmd/ingress/main.go
+++ b/modules/cloudevent-broker/cmd/ingress/main.go
@@ -16,6 +16,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/pubsub"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/kelseyhightower/envconfig"
 	"golang.org/x/oauth2/google"
@@ -25,8 +26,8 @@ import (
 	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
+	"github.com/chainguard-dev/terraform-infra-common/pkg/profiler"
 	cgpubsub "github.com/chainguard-dev/terraform-infra-common/pkg/pubsub"
-	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
 const (
@@ -40,6 +41,8 @@ type envConfig struct {
 }
 
 func main() {
+	profiler.SetupProfiler()
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 

--- a/modules/cloudevent-recorder/cmd/recorder/main.go
+++ b/modules/cloudevent-recorder/cmd/recorder/main.go
@@ -11,12 +11,14 @@ import (
 	"os/signal"
 	"path/filepath"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/kelseyhightower/envconfig"
+
 	"github.com/chainguard-dev/clog"
 	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/chainguard-dev/terraform-infra-common/pkg/profiler"
 )
 
 type envConfig struct {
@@ -25,10 +27,13 @@ type envConfig struct {
 }
 
 func main() {
+	profiler.SetupProfiler()
+
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
+		clog.Fatalf("failed to process env var: %v", err)
 	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package profiler
+
+import (
+	"os"
+
+	"cloud.google.com/go/profiler"
+	"github.com/kelseyhightower/envconfig"
+
+	"github.com/chainguard-dev/clog"
+)
+
+type envConfig struct {
+	EnableProfiler bool `envconfig:"ENABLE_PROFILER" default:"false" required:"false"`
+}
+
+func SetupProfiler() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		clog.Fatalf("failed to process env var: %v", err)
+	}
+
+	if env.EnableProfiler {
+		if err := profiler.Start(profiler.Config{Service: os.Getenv("K_SERVICE")}); err != nil {
+			clog.Fatalf("failed to start profiler: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
a secure way to get profiling data while running on gcp
https://cloud.google.com/profiler/docs/profiling-go

if we decide to adopt `cloud profiler` across the board, we may consider ripping out `pprof` completely


we can use `pprof`, but we would have to register the `pprof` endpoints on the application port, as cloudrun only allows a single port.
we can block external traffic to `/debug/pprof` with cloud armor, and only access via the `*.run.app` host

both options would require enabling
pprof would still require
- tunneling
- curl endpoint with identity token