### PR TITLE
add sample terraform test based e2e tests

### DIFF
--- a/modules/regional-go-service/outputs.tf
+++ b/modules/regional-go-service/outputs.tf
@@ -3,3 +3,9 @@ output "names" {
     for k, v in google_cloud_run_v2_service.this : k => v.name
   }
 }
+
+output "uris" {
+  value = {
+    for k, v in google_cloud_run_v2_service.this : k => v.uri
+  }
+}

--- a/modules/regional-go-service/tests/asserts/main.tf
+++ b/modules/regional-go-service/tests/asserts/main.tf
@@ -1,0 +1,6 @@
+variable "endpoint" {}
+
+data "http" "endpoint" {
+  url    = var.endpoint
+  method = "GET"
+}

--- a/modules/regional-go-service/tests/cmd/main.go
+++ b/modules/regional-go-service/tests/cmd/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/modules/regional-go-service/tests/setup/main.tf
+++ b/modules/regional-go-service/tests/setup/main.tf
@@ -1,0 +1,24 @@
+variable "project_id" {}
+
+resource "random_string" "name" {
+  numeric = false
+  upper   = false
+  special = false
+  length  = 6
+}
+
+resource "google_service_account" "iam" {
+  project = var.project_id
+
+  account_id   = random_string.name.id
+  display_name = "test-${random_string.name.id}"
+  description  = "Dedicated service account for ${random_string.name.id}"
+}
+
+output "name" {
+  value = random_string.name.id
+}
+
+output "email" {
+  value = google_service_account.iam.email
+}

--- a/modules/regional-go-service/tests/valid.tftest.hcl
+++ b/modules/regional-go-service/tests/valid.tftest.hcl
@@ -1,0 +1,60 @@
+variables {
+  # set with -var 'project=your-project-id'
+  # project_id = ""
+}
+
+run "setup" {
+  module {
+    source = "./tests/setup/"
+  }
+}
+
+run "create" {
+  variables {
+    name = run.setup.name
+    project_id = var.project_id
+    regions = {
+      "us-central1" = {
+        network = "default"
+        subnet = "default"
+      }
+    }
+
+    service_account = run.setup.email
+
+    ingress = "INGRESS_TRAFFIC_ALL"
+    egress = "ALL_TRAFFIC"
+
+    containers = {
+      "hello" = {
+        source = {
+          working_dir = "./tests"
+          importpath = "./cmd/"
+        }
+        ports = [{ container_port = 8080 }]
+      }
+    }
+
+    notification_channels = []
+  }
+
+  assert {
+    condition = google_cloud_run_v2_service.this["us-central1"].terminal_condition[0].type == "Ready"
+    error_message = "Service not ready"
+  }
+}
+
+run "validate" {
+  module {
+    source = "./tests/asserts/"
+  }
+
+  variables {
+    endpoint = "${run.create.uris["us-central1"]}/bar"
+  }
+
+  assert {
+    condition = data.http.endpoint.status_code == 200
+    error_message = "Website responded with HTTP status ${data.http.endpoint.status_code}"
+  }
+}


### PR DESCRIPTION
I don't _love_ the `terraform test` framework, but it seems good enough for some basic smoke testing.

There's a lot of indirection going on that could potentially be addressed in future terraform versions, like the need for `modules` to represent more complex assertions. Which is weird because `checks` seem to support inline data/resources... regardless, this has potential and is better than what we currently do (nothing).

this still needs new GHA workflows to accompany it.