### PR TITLE
grant profiler agent role to SA in regional-go-service

### DIFF
--- a/modules/regional-go-service/README.md
+++ b/modules/regional-go-service/README.md
@@ -86,6 +86,7 @@ No requirements.
 | [google_monitoring_alert_policy.anomalous-service-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.bad-rollout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_project_iam_member.metrics-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.profiler-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.trace-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [ko_build.this](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/build) | resource |
 | [google_client_openid_userinfo.me](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |

--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -30,6 +30,12 @@ resource "google_project_iam_member" "trace-writer" {
   member  = "serviceAccount:${var.service_account}"
 }
 
+resource "google_project_iam_member" "profiler-writer" {
+  project = var.project_id
+  role    = "roles/cloudprofiler.agent"
+  member  = "serviceAccount:${var.service_account}"
+}
+
 // Build each of the application images from source.
 resource "ko_build" "this" {
   for_each    = var.containers


### PR DESCRIPTION
turn on debug logging while setting this up initially

it does work
https://console.cloud.google.com/profiler/cr-dev-api/cpu?referrer=search&project=kleung-chainguard&supportedpurview=project