### PR TITLE
drop the now redundant *github type from the handlers

### DIFF
--- a/modules/github-bots/dnm/dnm.go
+++ b/modules/github-bots/dnm/dnm.go
@@ -13,19 +13,19 @@ const label = "blocking/dnm"
 func New() sdk.Bot {
 	name := "dnm"
 
-	handler := sdk.PullRequestHandler(func(ctx context.Context, pre github.PullRequestEvent, pr *github.PullRequest) error {
+	handler := sdk.PullRequestHandler(func(ctx context.Context, pre github.PullRequestEvent) error {
 		cli := sdk.NewGitHubClient(ctx, *pre.Repo.Owner.Login, *pre.Repo.Name, name)
 		defer cli.Close(ctx)
 
 		// If the title contains some variant of "dnm" and the PR doesn't have the label, add it -- this will no-op if it already has it.
 		for _, dnm := range []string{name, "do not merge", "donotmerge", "do-not-merge"} {
-			if strings.Contains(strings.ToLower(*pr.Title), dnm) {
-				return cli.AddLabel(ctx, pr, label)
+			if strings.Contains(strings.ToLower(*pre.PullRequest.Title), dnm) {
+				return cli.AddLabel(ctx, pre.PullRequest, label)
 			}
 		}
 
 		// If it has the label and the title doesn't match, remove the label -- this will no-op if it already doesn't have it.
-		return cli.RemoveLabel(ctx, pr, label)
+		return cli.RemoveLabel(ctx, pre.PullRequest, label)
 	})
 
 	return sdk.NewBot(name,

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -128,7 +128,7 @@ func Serve(b Bot) {
 					return err
 				}
 
-				if err := h(ctx, wre.Body, wr); err != nil {
+				if err := h(ctx, wre.Body); err != nil {
 					logger.Errorf("failed to handle workflow run event: %v", err)
 					return err
 				}
@@ -149,7 +149,7 @@ func Serve(b Bot) {
 					return err
 				}
 
-				if err := h(ctx, pre.Body, pr); err != nil {
+				if err := h(ctx, pre.Body); err != nil {
 					logger.Errorf("failed to handle pull request event: %v", err)
 					return err
 				}
@@ -170,7 +170,7 @@ func Serve(b Bot) {
 					return err
 				}
 
-				if err := h(ctx, ice.Body, ic); err != nil {
+				if err := h(ctx, ice.Body); err != nil {
 					logger.Errorf("failed to handle issue comment event: %v", err)
 					return err
 				}

--- a/modules/github-bots/sdk/handlers.go
+++ b/modules/github-bots/sdk/handlers.go
@@ -10,19 +10,19 @@ type EventHandlerFunc interface {
 	EventType() EventType
 }
 
-type PullRequestHandler func(ctx context.Context, pre github.PullRequestEvent, pr *github.PullRequest) error
+type PullRequestHandler func(ctx context.Context, pre github.PullRequestEvent) error
 
 func (r PullRequestHandler) EventType() EventType {
 	return PullRequestEvent
 }
 
-type WorkflowRunHandler func(ctx context.Context, wre github.WorkflowRunEvent, wr *github.WorkflowRun) error
+type WorkflowRunHandler func(ctx context.Context, wre github.WorkflowRunEvent) error
 
 func (r WorkflowRunHandler) EventType() EventType {
 	return WorkflowRunEvent
 }
 
-type IssueCommentHandler func(ctx context.Context, ice github.IssueCommentEvent, ic *github.IssueComment) error
+type IssueCommentHandler func(ctx context.Context, ice github.IssueCommentEvent) error
 
 func (r IssueCommentHandler) EventType() EventType {
 	return IssueCommentEvent

--- a/modules/github-bots/time/time.go
+++ b/modules/github-bots/time/time.go
@@ -12,11 +12,11 @@ import (
 func New() sdk.Bot {
 	name := "time"
 
-	handler := sdk.PullRequestHandler(func(ctx context.Context, pre github.PullRequestEvent, pr *github.PullRequest) error {
+	handler := sdk.PullRequestHandler(func(ctx context.Context, pre github.PullRequestEvent) error {
 		cli := sdk.NewGitHubClient(ctx, *pre.Repo.Owner.Login, *pre.Repo.Name, name)
 		defer cli.Close(ctx)
 
-		return cli.SetComment(ctx, pr, name, fmt.Sprintf("The time is now %s", time.Now().Format(time.RFC3339)))
+		return cli.SetComment(ctx, pre.PullRequest, name, fmt.Sprintf("The time is now %s", time.Now().Format(time.RFC3339)))
 	})
 
 	return sdk.NewBot(name,


### PR DESCRIPTION
https://github.com/chainguard-dev/terraform-infra-common/pull/270 means we're forwarding the full event now, which means we can drop the extra, now redundant *github type from the bot handlers