### PR TITLE
Add a clone of idtoken.NewClient() that is more compatible with our metrics Transport

### DIFF
--- a/pkg/httpmetrics/idtoken.go
+++ b/pkg/httpmetrics/idtoken.go
@@ -23,7 +23,7 @@ import (
 //
 // We can't just use the option.WithHTTPClient and call upstream idtoken.NewClient()
 // because that code always reads from the http.DefaultTransport anyway.
-func newIdTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
+func newIDTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
 	// unwrap the transport from the metrics transport
 	innerTransport := ExtractInnerTransport(http.DefaultTransport)
 	httpTransport := innerTransport.(*http.Transport).Clone()
@@ -46,9 +46,9 @@ func newIdTokenClient(ctx context.Context, audience string, opts ...idtoken.Clie
 	return &http.Client{Transport: t}, nil
 }
 
-// NewIdTokenClient creates a new http.Client based on idtoken.Client, with metrics.
-func NewIdTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
-	c, err := newIdTokenClient(ctx, audience, opts...)
+// NewIDTokenClient creates a new http.Client based on idtoken.Client, with metrics.
+func NewIDTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
+	c, err := newIDTokenClient(ctx, audience, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpmetrics/idtoken.go
+++ b/pkg/httpmetrics/idtoken.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+package httpmetrics
+
+import (
+	"context"
+	"net/http"
+
+	"google.golang.org/api/idtoken"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	htransport "google.golang.org/api/transport/http"
+)
+
+// newIdTokenClient creates a new http.Client, similar to that of idtoken.NewClient(),
+// but with understanding of how we wrap the DefaultTransport for metrics.
+//
+// Based on
+// https://github.com/googleapis/google-api-go-client/blob/v0.178.0/idtoken/idtoken.go#L46
+// but skipping the opts validation that can't be performed here because private types.
+//
+// We can't just use the option.WithHTTPClient and call upstream idtoken.NewClient()
+// because that code always reads from the http.DefaultTransport anyway.
+func newIdTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
+	// unwrap the transport from the metrics transport
+	innerTransport := ExtractInnerTransport(http.DefaultTransport)
+	httpTransport := innerTransport.(*http.Transport).Clone()
+
+	// Everything else after this point is based on
+	// https://github.com/googleapis/google-api-go-client/blob/v0.178.0/idtoken/idtoken.go#L46
+	ts, err := idtoken.NewTokenSource(ctx, audience, opts...)
+	if err != nil {
+		return nil, err
+	}
+	// Skip DialSettings validation so added TokenSource will not conflict with user
+	// provided credentials.
+	opts = append(opts, option.WithTokenSource(ts), internaloption.SkipDialSettingsValidation())
+
+	httpTransport.MaxIdleConnsPerHost = 100
+	t, err := htransport.NewTransport(ctx, httpTransport, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: t}, nil
+}
+
+// NewIdTokenClient creates a new http.Client based on idtoken.Client, with metrics.
+func NewIdTokenClient(ctx context.Context, audience string, opts ...idtoken.ClientOption) (*http.Client, error) {
+	c, err := newIdTokenClient(ctx, audience, opts...)
+	if err != nil {
+		return nil, err
+	}
+	c.Transport = WrapTransport(c.Transport)
+	return c, nil
+}

--- a/pkg/httpmetrics/idtoken_test.go
+++ b/pkg/httpmetrics/idtoken_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+package httpmetrics
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/option"
+)
+
+func TestNewIdTokenClient(t *testing.T) {
+	aud := "https://example.com"
+	ctx := context.Background()
+	t.Run("with regular transport", func(t *testing.T) {
+		_, err := NewIdTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
+		if err != nil {
+			t.Fatalf("NewIdTokenClient() = %v", err)
+		}
+	})
+	t.Run("with wrapped transport", func(t *testing.T) {
+		prev := http.DefaultTransport
+		http.DefaultTransport = WrapTransport(http.DefaultTransport)
+		defer func() {
+			http.DefaultTransport = prev
+		}()
+		_, err := NewIdTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
+		if err != nil {
+			t.Fatalf("NewIdTokenClient() = %v", err)
+		}
+	})
+}

--- a/pkg/httpmetrics/idtoken_test.go
+++ b/pkg/httpmetrics/idtoken_test.go
@@ -12,13 +12,13 @@ import (
 	"google.golang.org/api/option"
 )
 
-func TestNewIdTokenClient(t *testing.T) {
+func TestNewIDTokenClient(t *testing.T) {
 	aud := "https://example.com"
 	ctx := context.Background()
 	t.Run("with regular transport", func(t *testing.T) {
-		_, err := NewIdTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
+		_, err := NewIDTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
 		if err != nil {
-			t.Fatalf("NewIdTokenClient() = %v", err)
+			t.Fatalf("NewIDTokenClient() = %v", err)
 		}
 	})
 	t.Run("with wrapped transport", func(t *testing.T) {
@@ -27,7 +27,7 @@ func TestNewIdTokenClient(t *testing.T) {
 		defer func() {
 			http.DefaultTransport = prev
 		}()
-		_, err := NewIdTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
+		_, err := NewIDTokenClient(ctx, aud, option.WithCredentialsFile("testdata/creds.json"))
 		if err != nil {
 			t.Fatalf("NewIdTokenClient() = %v", err)
 		}

--- a/pkg/httpmetrics/testdata/creds.json
+++ b/pkg/httpmetrics/testdata/creds.json
@@ -1,0 +1,5 @@
+{
+    "type": "external_account",
+    "audience": "https://example.com",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt"
+}

--- a/pkg/httpmetrics/transport_test.go
+++ b/pkg/httpmetrics/transport_test.go
@@ -43,7 +43,7 @@ func TestExtractInnerTransport(t *testing.T) {
 
 	t.Run("wrapped", func(t *testing.T) {
 		inner := &http.Transport{}
-		var tr http.RoundTripper = WrapTransport(inner)
+		var tr = WrapTransport(inner)
 		if got := ExtractInnerTransport(tr); got != inner {
 			t.Errorf("want %v, got %v", inner, got)
 		}

--- a/pkg/httpmetrics/transport_test.go
+++ b/pkg/httpmetrics/transport_test.go
@@ -32,3 +32,20 @@ func TestTransport(t *testing.T) {
 		t.Errorf("want metric count = 1, got %f", got)
 	}
 }
+
+func TestExtractInnerTransport(t *testing.T) {
+	t.Run("not wrapped", func(t *testing.T) {
+		tr := &http.Transport{}
+		if got := ExtractInnerTransport(tr); got != tr {
+			t.Errorf("want %v, got %v", tr, got)
+		}
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		inner := &http.Transport{}
+		var tr http.RoundTripper = WrapTransport(inner)
+		if got := ExtractInnerTransport(tr); got != inner {
+			t.Errorf("want %v, got %v", inner, got)
+		}
+	})
+}


### PR DESCRIPTION
This function is based on https://github.com/googleapis/google-api-go-client/blob/v0.178.0/idtoken/idtoken.go#L46
but skipping the opts validation that can't be performed here because private types.

We can't just use the `option.WithHTTPClient` and call upstream `idtoken.NewClient()` because that code always tries to cast from the `http.DefaultTransport` anyway, no matter if `option.WithHTTPClient()` is used or not ([see](https://github.com/googleapis/google-api-go-client/blob/v0.178.0/idtoken/idtoken.go#L73)).