### PR TITLE
support ReaderAt for GH file retrievals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cloud.google.com/go/profiler v0.4.0
 	cloud.google.com/go/pubsub v1.38.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.23.0
+	github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270
 	github.com/chainguard-dev/clog v1.3.1
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.10.0
@@ -17,6 +18,7 @@ require (
 	github.com/google/go-github/v61 v61.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.19.0
+	github.com/snabb/httpreaderat v1.0.1
 	go.opentelemetry.io/contrib/detectors/gcp v1.26.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0
 	go.opentelemetry.io/otel v1.26.0
@@ -71,6 +73,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.51.1 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.47.0/go.mod h1:ZC7rjqRzdhRKDK223jQ7Tsz89ZtrSSLH/VFzf7k5Sb0=
 github.com/apache/arrow/go/v15 v15.0.2 h1:60IliRbiyTWCWjERBCkO1W4Qun9svcYoZrSLcyOsMLE=
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
+github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270 h1:JIxGEMs4E5Zb6R7z2C5IgecI0mkqS97WAEF31wUbYTM=
+github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270/go.mod h1:2XtVRGCw/HthOLxU0Qw6o6jSJrcEoOb2OCCl8gQYvGw=
 github.com/aws/aws-sdk-go v1.50.36 h1:PjWXHwZPuTLMR1NIb8nEjLucZBMzmf84TLoLbD8BZqk=
 github.com/aws/aws-sdk-go v1.50.36/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.26.0 h1:/Ce4OCiM3EkpW7Y+xUnfAFpchU78K7/Ug01sZni9PgA=
@@ -223,6 +225,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -243,6 +247,8 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/snabb/httpreaderat v1.0.1 h1:whlb+vuZmyjqVop8x1EKOg05l2NE4z9lsMMXjmSUCnY=
+github.com/snabb/httpreaderat v1.0.1/go.mod h1:lpbGrKDWF37yvRbtRvQsbesS6Ty5c83t8ztannPoMsA=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"sync"
 
+	bufra "github.com/avvmoto/buf-readerat"
+	"github.com/snabb/httpreaderat"
+
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/octosts"
 	"github.com/google/go-github/v61/github"
@@ -31,6 +34,8 @@ func NewGitHubClient(ctx context.Context, org, repo, policyName string) GitHubCl
 	return GitHubClient{
 		inner: github.NewClient(oauth2.NewClient(ctx, ts)),
 		ts:    ts,
+		// TODO: Make this configurable?
+		bufSize: 1024 * 1024, // 1MB buffer for requests
 	}
 }
 
@@ -54,8 +59,9 @@ func (ts *tokenSource) Token() (*oauth2.Token, error) {
 }
 
 type GitHubClient struct {
-	inner *github.Client
-	ts    *tokenSource
+	inner   *github.Client
+	ts      *tokenSource
+	bufSize int
 }
 
 func (c GitHubClient) Client() *github.Client { return c.inner }
@@ -136,6 +142,7 @@ func (c GitHubClient) SetComment(ctx context.Context, pr *github.PullRequest, bo
 	return nil
 }
 
+// Deprecated: use FetchWorkflowRunLogs instead.
 func (c GitHubClient) GetWorkflowRunLogs(ctx context.Context, wre github.WorkflowRunEvent) ([]byte, error) {
 	logURL, resp, err := c.inner.Actions.GetWorkflowRunLogs(ctx, *wre.Repo.Owner.Login, *wre.Repo.Name, *wre.WorkflowRun.ID, 3)
 	if err != nil {
@@ -166,6 +173,31 @@ func (c GitHubClient) GetWorkflowRunLogs(ctx context.Context, wre github.Workflo
 	}
 
 	return body, nil
+}
+
+// FetchWorkflowRunLogs returns a Reader for the logs of the given WorkflowRun
+func (c GitHubClient) FetchWorkflowRunLogs(ctx context.Context, wr *github.WorkflowRun) (io.ReaderAt, error) {
+	url, ghresp, err := c.inner.Actions.GetWorkflowRunLogs(ctx, *wr.Repository.Owner.Login, *wr.Repository.Name, *wr.ID, 3)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate log retrieval: %w", err)
+	}
+	defer ghresp.Body.Close()
+
+	if ghresp.StatusCode != http.StatusFound {
+		return nil, fmt.Errorf("failed to find log artifact (%d) for workflow [%s]: %s", *wr.ID, *wr.Name, ghresp.Status)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	htdrd, err := httpreaderat.New(nil, req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return bufra.NewBufReaderAt(htdrd, c.bufSize), nil
 }
 
 func (c GitHubClient) GetWorkloadRunPullRequestNumber(ctx context.Context, wre github.WorkflowRunEvent) (int, error) {
@@ -199,6 +231,7 @@ func (c GitHubClient) GetWorkloadRunPullRequestNumber(ctx context.Context, wre g
 	return 0, fmt.Errorf("no matching pull request found")
 }
 
+// Deprecated: Use FetchWorkflowRunArtifact instead.
 func (c GitHubClient) GetWorkflowRunArtifact(ctx context.Context, wr *github.WorkflowRun, name string) (*zip.Reader, error) {
 	owner, repo := *wr.Repository.Owner.Login, *wr.Repository.Name
 
@@ -242,7 +275,57 @@ func (c GitHubClient) GetWorkflowRunArtifact(ctx context.Context, wr *github.Wor
 		if err != nil {
 			return nil, fmt.Errorf("failed to create zip reader: %w", err)
 		}
+		zr = r
+	}
 
+	if zr == nil {
+		return nil, fmt.Errorf("artifact %s for workflow_run %d not found", name, *wr.ID)
+	}
+
+	return zr, nil
+}
+
+// FetchWorkflowRunArtifact returns a zip reader for the artifact with `name` from the given WorkflowRun.
+func (c GitHubClient) FetchWorkflowRunArtifact(ctx context.Context, wr *github.WorkflowRun, name string) (*zip.Reader, error) {
+	owner, repo := *wr.Repository.Owner.Login, *wr.Repository.Name
+
+	artifacts, _, err := c.inner.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, *wr.ID, &github.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workflow run [%d] artifacts: %w", *wr.ID, err)
+	}
+
+	var zr *zip.Reader
+	for _, a := range artifacts.Artifacts {
+		if *a.Name != name {
+			continue
+		}
+
+		aid := a.GetID()
+		url, ghresp, err := c.inner.Actions.DownloadArtifact(ctx, owner, repo, aid, 10)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download artifact (%s) [%d]: %w", name, aid, err)
+		}
+
+		if ghresp.StatusCode != http.StatusFound {
+			return nil, fmt.Errorf("failed to find artifact (%s) [%d]: %s", name, aid, ghresp.Status)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		htdrd, err := httpreaderat.New(nil, req, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		bhtrdr := bufra.NewBufReaderAt(htdrd, c.bufSize)
+
+		r, err := zip.NewReader(bhtrdr, htdrd.Size())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create zip reader: %w", err)
+		}
 		zr = r
 	}
 


### PR DESCRIPTION
Create new `Fetch*` alternative functions for retrieving `io.ReaderAt`s for the helper methods that deal with get'ing arbitrary files from GH (logs and artifacts).

This stops us from arbitrarily buffering the entire contents into memory, and restricts the buffer size to 1mb for now. This currently isn't configurable, but wouldn't be hard to make it configurable if needed.

This also marks the old `Get*` functions as deprecated.