### PR TITLE
allow specifying different project for workload identity federation then the google service account

### DIFF
--- a/modules/github-gsa/README.md
+++ b/modules/github-gsa/README.md
@@ -65,6 +65,7 @@ No requirements.
 | <a name="input_refspec"></a> [refspec](#input\_refspec) | The refspec to allow to federate with this identity. | `string` | n/a | yes |
 | <a name="input_repository"></a> [repository](#input\_repository) | The name of the repository to allow to assume this identity. | `string` | n/a | yes |
 | <a name="input_wif-pool"></a> [wif-pool](#input\_wif-pool) | The name of the Workload Identity Federation pool. | `string` | n/a | yes |
+| <a name="input_wif_project_id"></a> [wif\_project\_id](#input\_wif\_project\_id) | n/a | `string` | `""` | no |
 | <a name="input_workflow_ref"></a> [workflow\_ref](#input\_workflow\_ref) | The workflow to allow to federate with this identity (e.g. .github/workflows/deploy.yaml). | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/github-gsa/main.tf
+++ b/modules/github-gsa/main.tf
@@ -114,6 +114,8 @@ locals {
 
 // Create the IAM binding allowing workflows to impersonate the service account.
 resource "google_service_account_iam_binding" "allow-impersonation" {
+  project_id = var.wif_project_id != "" ? var.wif_project_id : var.project_id
+
   service_account_id = google_service_account.this.name
   role               = "roles/iam.workloadIdentityUser"
 
@@ -123,11 +125,11 @@ resource "google_service_account_iam_binding" "allow-impersonation" {
 
   lifecycle {
     precondition {
-      condition = var.audit_workflow_ref == "" || var.workflow_ref == "*"
+      condition     = var.audit_workflow_ref == "" || var.workflow_ref == "*"
       error_message = "audit_workflow_ref may only be specified when workflow_ref is '*'"
     }
     precondition {
-      condition = var.audit_refspec == "" || var.refspec == "*"
+      condition     = var.audit_refspec == "" || var.refspec == "*"
       error_message = "audit_refspec may only be specified when refspec is '*'"
     }
   }
@@ -138,7 +140,7 @@ resource "google_service_account_iam_binding" "allow-impersonation" {
 module "audit-usage" {
   source = "../audit-serviceaccount"
 
-  project_id      = var.project_id
+  project_id      = var.wif_project_id != "" ? var.wif_project_id : var.project_id
   service-account = google_service_account.this.email
 
   allowed_principal_regex = local.principalSubject

--- a/modules/github-gsa/variables.tf
+++ b/modules/github-gsa/variables.tf
@@ -2,6 +2,11 @@ variable "project_id" {
   type = string
 }
 
+variable "wif_project_id" {
+  type    = string
+  default = ""
+}
+
 variable "name" {
   description = "The name to give the service account."
   type        = string


### PR DESCRIPTION
the default behaviors is unchanged, using the `project_id` for both service account and workload identity federation
it will only use `wif_project_id` if one is explicitly specified

this is so we can set the principalset iam in the workload identity federation project, and keep the google service account in a different one.

use case: use the workload identity pool in the "shared" project, but grant it permission in the "images" project.

