### PR TITLE
Remove non-existent field from docs

### DIFF
--- a/modules/github-bots/README.md
+++ b/modules/github-bots/README.md
@@ -61,10 +61,19 @@ module "my-custom-bot" {
 
   name         = "my-custom-bot"
   github-event = "dev.chainguard.github.pull_request"
-  source_code = {
-    importpath  = "./cmd/custom/bot"
-    working_dir = path.module
-  }
+  containers = {
+    "bot" = {
+      source = {
+        working_dir = path.module
+        importpath  = "chainguard.dev/bots/my-custom-bot"
+      }
+      ports = [{ container_port = 8080 }]
+      env = [{
+        name  = "LOG_LEVEL"
+        value = "info"
+      }]
+    }
+
 }
 ```
 


### PR DESCRIPTION
The `source_code` field was removed, which is misleading in the docs