### PR TITLE
Add a pull subscription to the dead-letter topics

### DIFF
--- a/modules/bucket-events/README.md
+++ b/modules/bucket-events/README.md
@@ -97,6 +97,7 @@ No requirements.
 |------|------|
 | [google-beta_google_project_service_identity.pubsub](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_monitoring_dashboard.dashboard](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
+| [google_pubsub_subscription.dead-letter-pull-sub](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_binding.allow-pubsub-to-ack](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
 | [google_pubsub_topic.dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |

--- a/modules/bucket-events/main.tf
+++ b/modules/bucket-events/main.tf
@@ -114,6 +114,21 @@ resource "google_pubsub_topic" "dead-letter" {
   }
 }
 
+// Create a subscription to the dead-letter topic so dead-lettered messages
+// are retained. This also allows us to alerts based on better metrics
+// like the age or count of dead-lettered messages.
+resource "google_pubsub_subscription" "dead-letter-pull-sub" {
+  name                       = google_pubsub_topic.dead-letter.name
+  topic                      = google_pubsub_topic.dead-letter.name
+  message_retention_duration = "86400s"
+
+  expiration_policy {
+    ttl = "86400s"
+  }
+
+  enable_message_ordering = true
+}
+
 // Grant the pubsub service account the ability to send to the dead-letter topic.
 resource "google_pubsub_topic_iam_binding" "allow-pubsub-to-send-to-dead-letter" {
   topic = google_pubsub_topic.dead-letter.name

--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -109,6 +109,7 @@ No requirements.
 | [google_bigquery_table_iam_binding.import-writes-to-tables](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_binding) | resource |
 | [google_monitoring_alert_policy.bq_dts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.bucket-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_pubsub_subscription.dead-letter-pull-sub](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_binding.allow-pubsub-to-ack](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
 | [google_pubsub_topic.dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |

--- a/modules/cloudevent-trigger/README.md
+++ b/modules/cloudevent-trigger/README.md
@@ -101,6 +101,7 @@ No requirements.
 |------|------|
 | [google-beta_google_project_service_identity.pubsub](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_project_service_identity) | resource |
 | [google_monitoring_alert_policy.pubsub_dead_letter_queue_messages](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_pubsub_subscription.dead-letter-pull-sub](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_binding.allow-pubsub-to-ack](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
 | [google_pubsub_topic.dead-letter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |

--- a/modules/cloudevent-trigger/main.tf
+++ b/modules/cloudevent-trigger/main.tf
@@ -82,6 +82,21 @@ resource "google_pubsub_topic_iam_binding" "allow-pubsub-to-send-to-dead-letter"
   members = ["serviceAccount:${google_project_service_identity.pubsub.email}"]
 }
 
+// Create a subscription to the dead-letter topic so dead-lettered messages
+// are retained. This also allows us to alerts based on better metrics
+// like the age or count of dead-lettered messages.
+resource "google_pubsub_subscription" "dead-letter-pull-sub" {
+  name                       = google_pubsub_topic.dead-letter.name
+  topic                      = google_pubsub_topic.dead-letter.name
+  message_retention_duration = "86400s"
+
+  expiration_policy {
+    ttl = "86400s"
+  }
+
+  enable_message_ordering = true
+}
+
 // Configure the subscription to deliver the events matching our filter to this service
 // using the above identity to authorize the delivery..
 resource "google_pubsub_subscription" "this" {


### PR DESCRIPTION
This would retain dead-letter messages for further inspection. It also allows alerting based on better metrics, for example the number of dead-lettered messages:

![image](https://github.com/chainguard-dev/terraform-infra-common/assets/138266/33d9ce19-30c0-4cc1-9482-77b295150fbc)

The new metrics are better than the publish rate to the DLQ, it's hard to tell from the publish rate if a 100 messages were dead-lettered or only 1.

