### PR TITLE
github-bots: Add workflow run artifact handler

### DIFF
--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -113,8 +113,8 @@ func Serve(b Bot) {
 			ctx = context.WithValue(ctx, ContextKeyType, event.Type())
 
 			switch h := handler.(type) {
-			case WorkflowRunHandler:
-				logger.Debug("handling workflow run event")
+			case WorkflowRunArtifactHandler:
+				logger.Debug("handling workflow run artifact event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
@@ -122,9 +122,18 @@ func Serve(b Bot) {
 					return err
 				}
 
-				wr := &github.WorkflowRun{}
-				if err := marshalTo(wre.Body.WorkflowRun, wr); err != nil {
-					logger.Errorf("failed to marshal workflow run: %v", err)
+				if err := h(ctx, wre.Body); err != nil {
+					logger.Errorf("failed to handle workflow run event: %v", err)
+					return err
+				}
+				return nil
+
+			case WorkflowRunHandler:
+				logger.Debug("handling workflow run event")
+
+				var wre schemas.Wrapper[github.WorkflowRunEvent]
+				if err := event.DataAs(&wre); err != nil {
+					logger.Errorf("failed to unmarshal workflow run event: %v", err)
 					return err
 				}
 
@@ -143,12 +152,6 @@ func Serve(b Bot) {
 					return err
 				}
 
-				pr := &github.PullRequest{}
-				if err := marshalTo(pre.Body.PullRequest, pr); err != nil {
-					logger.Errorf("failed to marshal pull request event: %v", err)
-					return err
-				}
-
 				if err := h(ctx, pre.Body); err != nil {
 					logger.Errorf("failed to handle pull request event: %v", err)
 					return err
@@ -161,12 +164,6 @@ func Serve(b Bot) {
 				var ice schemas.Wrapper[github.IssueCommentEvent]
 				if err := event.DataAs(&ice); err != nil {
 					logger.Errorf("failed to unmarshal issue comment event: %v", err)
-					return err
-				}
-
-				ic := &github.IssueComment{}
-				if err := marshalTo(ice.Body.Comment, ic); err != nil {
-					logger.Errorf("failed to marshal issue comment: %v", err)
 					return err
 				}
 

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -182,14 +182,6 @@ func Serve(b Bot) {
 	}
 }
 
-func marshalTo(source any, target any) error {
-	b, err := json.Marshal(source)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(b, target)
-}
-
 // AttributeFromContext retrieves an attribute by key from the context.
 // Returns nil if the attribute does not exist.
 func AttributeFromContext(ctx context.Context, key string) interface{} {

--- a/modules/github-bots/sdk/handlers.go
+++ b/modules/github-bots/sdk/handlers.go
@@ -42,6 +42,6 @@ const (
 	WorkflowRunEvent  EventType = "dev.chainguard.github.workflow_run"
 	IssueCommentEvent EventType = "dev.chainguard.github.issue_comment"
 
-	// LoFo events (https://github.com/chainguard-dev/mono/tree/main/bots/lofo)
+	// LoFo events
 	WorkflowRunArtifactEvent EventType = "dev.chainguard.lofo.workflow_run_artifacts"
 )

--- a/modules/github-bots/sdk/handlers.go
+++ b/modules/github-bots/sdk/handlers.go
@@ -28,10 +28,20 @@ func (r IssueCommentHandler) EventType() EventType {
 	return IssueCommentEvent
 }
 
+type WorkflowRunArtifactHandler func(ctx context.Context, wre github.WorkflowRunEvent) error
+
+func (r WorkflowRunArtifactHandler) EventType() EventType {
+	return WorkflowRunArtifactEvent
+}
+
 type EventType string
 
 const (
+	// Github events (https://github.com/chainguard-dev/terraform-infra-common/tree/main/modules/github-events)
 	PullRequestEvent  EventType = "dev.chainguard.github.pull_request"
 	WorkflowRunEvent  EventType = "dev.chainguard.github.workflow_run"
 	IssueCommentEvent EventType = "dev.chainguard.github.issue_comment"
+
+	// LoFo events (https://github.com/chainguard-dev/mono/tree/main/bots/lofo)
+	WorkflowRunArtifactEvent EventType = "dev.chainguard.lofo.workflow_run_artifacts"
 )


### PR DESCRIPTION
Add a new handler for bots subscribing to `lofo` events https://github.com/chainguard-dev/mono/blob/main/bots/lofo

Once this is merged I can have lofo use `sdk.WorkflowRunArtifactEvent` so there is a single source of truth for the name across repos.