### PR TITLE
fix: remove conflicting property for cron success alert

### DIFF
--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -334,10 +334,6 @@ resource "google_monitoring_alert_policy" "success" {
   # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"
-
-    notification_rate_limit {
-      period = "3600s" // re-alert hourly if condition still valid.
-    }
   }
 
   display_name = "Cloud Run Job Success Execcution: ${var.name}"


### PR DESCRIPTION
```
│ Error: Error creating AlertPolicy: googleapi: Error 400: Field alertStrategy.notificationRateLimit had an invalid value of "period 	 { seconds: 3600 }": metric-based alert policies must not specify a notification rate limit
│ 
│   with module.notify-automation.module.populate-apkmetadata-cron.google_monitoring_alert_policy.success[0],
│   on .terraform/modules/notify-automation.populate-apkmetadata-cron/modules/cron/main.tf line 331, in resource "google_monitoring_alert_policy" "success":
│  331: resource "google_monitoring_alert_policy" "success" {
│ 
╵
Error: Process completed with exit code 1.
```