### PR TITLE
Create a dashboard per trigger to stay under widget limit

### DIFF
--- a/modules/cloudevent-recorder/README.md
+++ b/modules/cloudevent-recorder/README.md
@@ -151,6 +151,7 @@ No requirements.
 | <a name="input_provisioner"></a> [provisioner](#input\_provisioner) | The identity as which this module will be applied (so it may be granted permission to 'act as' the DTS service account).  This should be in the form expected by an IAM subject (e.g. user:sally@example.com) | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork.  A recorder service and cloud storage bucket (into which the service writes events) will be created in each region. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 | <a name="input_retention-period"></a> [retention-period](#input\_retention-period) | The number of days to retain data in BigQuery. | `number` | n/a | yes |
+| <a name="input_split_triggers"></a> [split\_triggers](#input\_split\_triggers) | Opt-in flag to split into per-trigger dashboards. Helpful when hitting widget limits | `bool` | `false` | no |
 | <a name="input_types"></a> [types](#input\_types) | A map from cloudevent types to the BigQuery schema associated with them, as well as an alert threshold and a list of notification channels (for subscription-level issues). | <pre>map(object({<br>    schema                = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>    partition_field       = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/cloudevent-recorder/recorder.tf
+++ b/modules/cloudevent-recorder/recorder.tf
@@ -112,6 +112,7 @@ module "recorder-dashboard" {
 
   alerts = tomap({ for type, schema in var.types : "BQ DTS ${var.name}-${type}" => google_monitoring_alert_policy.bq_dts[type].id })
 
+  split_triggers = var.split_triggers
   triggers = {
     for type, schema in var.types : "type: ${type}" => {
       subscription_prefix   = "${var.name}-${random_id.trigger-suffix[type].hex}"

--- a/modules/cloudevent-recorder/variables.tf
+++ b/modules/cloudevent-recorder/variables.tf
@@ -121,3 +121,9 @@ variable "enable_profiler" {
   default     = false
   description = "Enable cloud profiler."
 }
+
+variable "split_triggers" {
+  description = "Opt-in flag to split into per-trigger dashboards. Helpful when hitting widget limits"
+  type        = bool
+  default     = false
+}

--- a/modules/dashboard/cloudevent-receiver/README.md
+++ b/modules/dashboard/cloudevent-receiver/README.md
@@ -91,6 +91,7 @@ No requirements.
 | <a name="module_logs"></a> [logs](#module\_logs) | ../sections/logs | n/a |
 | <a name="module_resources"></a> [resources](#module\_resources) | ../sections/resources | n/a |
 | <a name="module_subscription"></a> [subscription](#module\_subscription) | ../sections/subscription | n/a |
+| <a name="module_trigger_layout"></a> [trigger\_layout](#module\_trigger\_layout) | ../sections/layout | n/a |
 | <a name="module_width"></a> [width](#module\_width) | ../sections/width | n/a |
 
 ## Resources
@@ -98,6 +99,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [google_monitoring_dashboard.dashboard](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
+| [google_monitoring_dashboard.trigger_dashboards](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
 
 ## Inputs
 
@@ -110,6 +112,7 @@ No requirements.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the GCP project | `string` | n/a | yes |
 | <a name="input_sections"></a> [sections](#input\_sections) | Sections to include in the dashboard | <pre>object({<br>    http   = optional(bool, true)  // Include HTTP section<br>    grpc   = optional(bool, true)  // Include GRPC section<br>    github = optional(bool, false) // Include GitHub API section<br>  })</pre> | <pre>{<br>  "github": false,<br>  "grpc": true,<br>  "http": true<br>}</pre> | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service(s) to monitor | `string` | n/a | yes |
+| <a name="input_split_triggers"></a> [split\_triggers](#input\_split\_triggers) | Opt-in flag to split into per-trigger dashboards. Helpful when hitting widget limits | `bool` | `false` | no |
 | <a name="input_triggers"></a> [triggers](#input\_triggers) | A mapping from a descriptive name to a subscription name prefix, an alert threshold, and list of notification channels. | <pre>map(object({<br>    subscription_prefix   = string<br>    alert_threshold       = optional(number, 50000)<br>    notification_channels = optional(list(string), [])<br>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -54,9 +54,50 @@ module "resources" {
 module "width" { source = "../sections/width" }
 
 module "layout" {
-  # Google cloud has a limit of 50 widgets per dashboard so we create a dashboard
-  # per trigger so services (like the recorder) with large amounts of triggers
-  # do not hit the widget limit.
+  count  = var.split_triggers ? 0 : 1
+  source = "../sections/layout"
+  sections = concat(
+    [for key in sort(keys(var.triggers)) : module.subscription[key].section],
+    [
+      module.errgrp.section,
+      module.logs.section,
+    ],
+    var.sections.http ? [module.http.section] : [],
+    var.sections.grpc ? [module.grpc.section] : [],
+    var.sections.github ? [module.github.section] : [],
+    [module.resources.section],
+  )
+}
+
+resource "google_monitoring_dashboard" "dashboard" {
+  count = var.split_triggers ? 0 : 1
+  dashboard_json = jsonencode({
+    displayName = "Cloud Event Receiver: ${var.service_name}"
+    labels = merge({
+      "service" : ""
+      "eventing" : ""
+    }, var.labels)
+    dashboardFilters = [{
+      filterType  = "RESOURCE_LABEL"
+      stringValue = var.service_name
+      labelKey    = "service_name"
+    }]
+
+    // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
+    mosaicLayout = {
+      columns = module.width.size
+      tiles   = module.layout.tiles,
+    }
+  })
+}
+
+# Google cloud has a limit of 50 widgets per dashboard so we create a dashboard
+# per trigger so services (like the recorder) with large amounts of triggers
+# do not hit the widget limit.
+#
+# This module is opt-in and will replace the layout module above
+module "trigger_layout" {
+  count    = var.split_triggers ? 1 : 0
   for_each = var.triggers
   source   = "../sections/layout"
   sections = concat([module.subscription[each.key].section],
@@ -71,10 +112,13 @@ module "layout" {
   )
 }
 
-resource "google_monitoring_dashboard" "dashboard" {
-  # Google cloud has a limit of 50 widgets per dashboard so we create a dashboard
-  # per trigger so services (like the recorder) with large amounts of triggers
-  # do not hit the widget limit.
+# Google cloud has a limit of 50 widgets per dashboard so we create a dashboard
+# per trigger so services (like the recorder) with large amounts of triggers
+# do not hit the widget limit.
+#
+# This resource is opt-in and will replace the dashboard resource above
+resource "google_monitoring_dashboard" "trigger_dashboards" {
+  count    = var.split_triggers ? 1 : 0
   for_each = var.triggers
   dashboard_json = jsonencode({
     displayName = "Cloud Event Receiver: ${var.service_name} (${each.key})"

--- a/modules/dashboard/cloudevent-receiver/variables.tf
+++ b/modules/dashboard/cloudevent-receiver/variables.tf
@@ -33,6 +33,12 @@ variable "alerts" {
   default     = {}
 }
 
+variable "split_triggers" {
+  description = "Opt-in flag to split into per-trigger dashboards. Helpful when hitting widget limits"
+  type        = bool
+  default     = false
+}
+
 variable "sections" {
   description = "Sections to include in the dashboard"
   type = object({


### PR DESCRIPTION
Slack context: https://chainguard-dev.slack.com/archives/C02SD39C6BW/p1715107930859599

We hit widget limits when adding more event types to the recorder. This is a pass at modifying the dashboard module to stay below the widget limit by creating a dashboard per trigger.