### PR TITLE
Fix the nesting of http metrics Transport span

### DIFF
--- a/pkg/httpmetrics/transport.go
+++ b/pkg/httpmetrics/transport.go
@@ -105,7 +105,9 @@ func instrumentRoundTripperCounter(next http.RoundTripper) promhttp.RoundTripper
 	return func(r *http.Request) (*http.Response, error) {
 		tracer := otel.Tracer("httpmetrics")
 		host := bucketize(r.URL.Host)
-		_, span := tracer.Start(r.Context(), fmt.Sprintf("http-%s-%s", r.Method, host))
+		ctx, span := tracer.Start(r.Context(), fmt.Sprintf("http-%s-%s", r.Method, host))
+		// Ensure that outgoing requests are nested under this span.
+		r = r.WithContext(ctx)
 		defer span.End()
 
 		resp, err := next.RoundTrip(r)


### PR DESCRIPTION
Currently it is like this:
![image](https://github.com/chainguard-dev/terraform-infra-common/assets/138266/e6e4abca-feb9-41bd-90de-b26ddc0e0d7e)

After fix:
![image](https://github.com/chainguard-dev/terraform-infra-common/assets/138266/aaf327e6-8d9c-4726-ad30-779d7b77e410)

