### PR TITLE
Specify handler name for otelhttp

### DIFF
--- a/pkg/httpmetrics/metrics.go
+++ b/pkg/httpmetrics/metrics.go
@@ -131,7 +131,7 @@ func Handler(name string, handler http.Handler) http.Handler {
 					counter.MustCurryWith(labels),
 					promhttp.InstrumentHandlerResponseSize(
 						responseSize.MustCurryWith(labels),
-						otelhttp.NewHandler(handler, ""),
+						otelhttp.NewHandler(handler, name),
 					),
 				),
 			),


### PR DESCRIPTION
otel uses this as the span display name (must be non-empty).