### PR TITLE
`mce.NewClientHTTP` to require name

### DIFF
--- a/modules/bucket-events/cmd/trampoline/main.go
+++ b/modules/bucket-events/cmd/trampoline/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	clog.DebugContextf(ctx, "env: %+v", env)
 
-	ceclient, err := mce.NewClientHTTP(mce.WithTarget(ctx, env.IngressURI)...)
+	ceclient, err := mce.NewClientHTTP("trampoline", mce.WithTarget(ctx, env.IngressURI)...)
 	if err != nil {
 		clog.FatalContextf(ctx, "failed to create cloudevents client: %v", err)
 	}

--- a/modules/cloudevent-broker/cmd/ingress/main.go
+++ b/modules/cloudevent-broker/cmd/ingress/main.go
@@ -54,7 +54,7 @@ func main() {
 	go httpmetrics.ServeMetrics()
 	defer httpmetrics.SetupTracer(ctx)()
 
-	c, err := mce.NewClientHTTP(cloudevents.WithPort(env.Port),
+	c, err := mce.NewClientHTTP("ce-ingress", cloudevents.WithPort(env.Port),
 		cehttp.WithRequestDataAtContextMiddleware() /* give request headers to the handler context */)
 	if err != nil {
 		clog.Fatalf("failed to create CE client, %v", err)

--- a/modules/cloudevent-recorder/cmd/recorder/main.go
+++ b/modules/cloudevent-recorder/cmd/recorder/main.go
@@ -40,7 +40,7 @@ func main() {
 	go httpmetrics.ServeMetrics()
 	defer httpmetrics.SetupTracer(ctx)()
 
-	c, err := mce.NewClientHTTP(cloudevents.WithPort(env.Port))
+	c, err := mce.NewClientHTTP("ce-recorder", cloudevents.WithPort(env.Port))
 	if err != nil {
 		clog.Fatalf("failed to create event client, %v", err)
 	}

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -81,7 +81,7 @@ func Serve(b Bot) {
 		"octo-sts.dev":   "octosts",
 	})
 
-	c, err := mce.NewClientHTTP(
+	c, err := mce.NewClientHTTP(b.Name,
 		cloudevents.WithPort(env.Port),
 	)
 	if err != nil {

--- a/modules/github-events/cmd/trampoline/main.go
+++ b/modules/github-events/cmd/trampoline/main.go
@@ -41,7 +41,7 @@ func main() {
 	go httpmetrics.ServeMetrics()
 	defer httpmetrics.SetupTracer(ctx)()
 
-	ceclient, err := mce.NewClientHTTP(mce.WithTarget(ctx, env.IngressURI)...)
+	ceclient, err := mce.NewClientHTTP("trampoline", mce.WithTarget(ctx, env.IngressURI)...)
 	if err != nil {
 		clog.FatalContextf(ctx, "failed to create cloudevents client: %v", err)
 	}

--- a/pkg/httpmetrics/cloudevents/client.go
+++ b/pkg/httpmetrics/cloudevents/client.go
@@ -14,7 +14,7 @@ import (
 	metrics "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 )
 
-func NewClientHTTP(opts ...cehttp.Option) (cloudevents.Client, error) {
+func NewClientHTTP(name string, opts ...cehttp.Option) (cloudevents.Client, error) {
 	// If we don't specify a client, NewClientHTTP will use http.DefaultClient
 	// and may clobber its Transport. To avoid so, we pass a client with the
 	// the metrics transport instead.
@@ -24,7 +24,7 @@ func NewClientHTTP(opts ...cehttp.Option) (cloudevents.Client, error) {
 	copt := append([]cehttp.Option{
 		cehttp.WithClient(metricsClient),
 		cloudevents.WithMiddleware(func(next http.Handler) http.Handler {
-			return metrics.Handler("cloudevents", next)
+			return metrics.Handler(name, next)
 		})}, opts...)
 	return cloudevents.NewClientHTTP(copt...)
 }


### PR DESCRIPTION
This will automatically add a span with said name around event handling. Currently that span is always named "cloudevents" which is confusing/redudant.

Intentionally break backward compat here to make sure all our usage to include a name.