### PR TITLE
preserve original trace headers for http

### DIFF
--- a/pkg/httpmetrics/preserve_traceparent.go
+++ b/pkg/httpmetrics/preserve_traceparent.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+package httpmetrics
+
+import (
+	"net/http"
+)
+
+func newPreserveTraceparentTransport(rt http.RoundTripper) http.RoundTripper {
+	return &preserveTraceparentTransport{rt}
+}
+
+type preserveTraceparentTransport struct {
+	http.RoundTripper
+}
+
+func preserveTraceparentHeader(r *http.Request) {
+	if v := r.Header.Get("traceparent"); v != "" {
+		r.Header.Set(OriginalTraceHeader, v)
+	}
+}
+
+func preserveTraceparentHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		preserveTraceparentHeader(r)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (pt *preserveTraceparentTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	preserveTraceparentHeader(r)
+	return pt.RoundTripper.RoundTrip(r)
+}


### PR DESCRIPTION
Similar to https://github.com/chainguard-dev/go-grpc-kit/pull/268, this saves the traceparent header before sending an HTTP request and restore it on the server side.

This avoids missing Cloud Run span causing broken trace hierearchy.