### PR TITLE
fix broken alert

### DIFF
--- a/modules/regional-service/README.md
+++ b/modules/regional-service/README.md
@@ -77,7 +77,8 @@ No requirements.
 | [google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
 | [google_monitoring_alert_policy.anomalous-service-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.bad-rollout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
-| [google_monitoring_alert_policy.crash](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.fatal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.panic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_project_iam_member.metrics-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.profiler-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.trace-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -365,8 +365,7 @@ resource "google_monitoring_alert_policy" "bad-rollout" {
   project = var.project_id
 }
 
-// Create an alert policy to notify if the service is struggling to rollout.
-resource "google_monitoring_alert_policy" "crash" {
+resource "google_monitoring_alert_policy" "panic" {
   # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"
@@ -376,7 +375,7 @@ resource "google_monitoring_alert_policy" "crash" {
     }
   }
 
-  display_name = "Panic|Fatal in: ${var.name}"
+  display_name = "Panic in: ${var.name}"
   combiner     = "OR"
 
   conditions {
@@ -395,6 +394,26 @@ resource "google_monitoring_alert_policy" "crash" {
       }
     }
   }
+
+  notification_channels = var.notification_channels
+
+  enabled = "true"
+  project = var.project_id
+}
+
+resource "google_monitoring_alert_policy" "fatal" {
+  # In the absence of data, incident will auto-close after an hour
+  alert_strategy {
+    auto_close = "3600s"
+
+    notification_rate_limit {
+      period = "3600s" // re-alert hourly if condition still valid.
+    }
+  }
+
+  display_name = "Fatal in: ${var.name}"
+  combiner     = "OR"
+
   conditions {
     display_name = "Fatal in: ${var.name}"
 
@@ -416,6 +435,7 @@ resource "google_monitoring_alert_policy" "crash" {
   enabled = "true"
   project = var.project_id
 }
+
 
 
 // When the service is behind a load balancer, then it is publicly exposed and responsible


### PR DESCRIPTION
```
│ Error: Error creating AlertPolicy: googleapi: Error 400: Alert policies with a log matching condition can only have a single condition.
│ 
│   with module.oidc-cloudrun.module.impersonation-service.module.this.google_monitoring_alert_policy.crash,
│   on .terraform/modules/oidc-cloudrun.impersonation-service/modules/regional-service/main.tf line 369, in resource "google_monitoring_alert_policy" "crash":
│  369: resource "google_monitoring_alert_policy" "crash" {
```