### PR TITLE
remove fatal alert from regional service

### DIFF
--- a/modules/regional-service/README.md
+++ b/modules/regional-service/README.md
@@ -77,7 +77,6 @@ No requirements.
 | [google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
 | [google_monitoring_alert_policy.anomalous-service-access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.bad-rollout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
-| [google_monitoring_alert_policy.fatal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.panic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_project_iam_member.metrics-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.profiler-writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -401,43 +401,6 @@ resource "google_monitoring_alert_policy" "panic" {
   project = var.project_id
 }
 
-resource "google_monitoring_alert_policy" "fatal" {
-  # In the absence of data, incident will auto-close after an hour
-  alert_strategy {
-    auto_close = "3600s"
-
-    notification_rate_limit {
-      period = "3600s" // re-alert hourly if condition still valid.
-    }
-  }
-
-  display_name = "Fatal in: ${var.name}"
-  combiner     = "OR"
-
-  conditions {
-    display_name = "Fatal in: ${var.name}"
-
-    condition_matched_log {
-      filter = <<EOT
-        resource.type="cloud_run_revision"
-        resource.labels.service_name="${var.name}"
-        textPayload:"fatal error: "
-      EOT
-
-      label_extractors = {
-        "revision_name" = "EXTRACT(resource.labels.revision_name)"
-      }
-    }
-  }
-
-  notification_channels = var.notification_channels
-
-  enabled = "true"
-  project = var.project_id
-}
-
-
-
 // When the service is behind a load balancer, then it is publicly exposed and responsible
 // for handling its own authentication.
 resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthenticated" {


### PR DESCRIPTION


Attempting to remove the `fatal` alert from each service to see if that is enough to bring us under 500.