### PR TITLE
remove extra quote that is breaking monitoring in mono

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -57,7 +57,7 @@ resource "google_monitoring_alert_policy" "oom" {
         logName: "/logs/run.googleapis.com%2Fvarlog%2Fsystem"
         severity=ERROR
         textPayload:"Consider increasing the memory limit"
-        ${var.oom_filter}"
+        ${var.oom_filter}
       EOT
 
       label_extractors = {


### PR DESCRIPTION
```
│ Error: Error updating AlertPolicy "projects/staging-enforce-cd1e/alertPolicies/10888012264146521460": googleapi: Error 400: Field alert_policy.conditions[0].filter had an invalid value of "        logName: "/logs/run.googleapis.com%2Fvarlog%2Fsystem"
│         severity=ERROR
│         textPayload:"Consider increasing the memory limit"
│         -resource.labels.backend_service_name=enforce-staging-ing-vuln"
│ ": Unparseable filter: syntax error at line 4, column 71, token '"'
```