### PR TITLE
add alert for go panic stacktrace

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -108,6 +108,41 @@ resource "google_monitoring_alert_policy" "panic" {
   project = var.project_id
 }
 
+resource "google_monitoring_alert_policy" "panic-stacktrace" {
+  # In the absence of data, incident will auto-close after an hour
+  alert_strategy {
+    auto_close = "3600s"
+
+    notification_rate_limit {
+      period = "3600s" // re-alert hourly if condition still valid.
+    }
+  }
+
+  display_name = "Panic stacktrace log entry"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Panic stacktrace log entry"
+
+    condition_matched_log {
+      filter = <<EOT
+        resource.type="cloud_run_revision"
+        jsonPayload.stacktrace:"runtime.gopanic"
+      EOT
+
+      label_extractors = {
+        "revision_name" = "EXTRACT(resource.labels.revision_name)"
+        "location"      = "EXTRACT(resource.labels.location)"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+
+  enabled = "true"
+  project = var.project_id
+}
+
 resource "google_monitoring_alert_policy" "fatal" {
   # In the absence of data, incident will auto-close after an hour
   alert_strategy {


### PR DESCRIPTION
this is different from the previous alert where the panic is printed to stderr/stdout

this panic is exposed as a stacktrace, which the previous alert did not catch.