### PR TITLE
make duration for the failure rate alert configurable

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -188,7 +188,7 @@ resource "google_monitoring_alert_policy" "service_failure_rate" {
 
   conditions {
     condition_monitoring_query_language {
-      duration = "0s"
+      duration = "120s"
       query    = <<EOT
         fetch cloud_run_revision
         | metric 'run.googleapis.com/request_count'

--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -188,7 +188,7 @@ resource "google_monitoring_alert_policy" "service_failure_rate" {
 
   conditions {
     condition_monitoring_query_language {
-      duration = "120s"
+      duration = "${var.failure_rate_duration}s"
       query    = <<EOT
         fetch cloud_run_revision
         | metric 'run.googleapis.com/request_count'

--- a/modules/alerting/variables.tf
+++ b/modules/alerting/variables.tf
@@ -17,3 +17,9 @@ variable "failure_rate_ratio_threshold" {
   type        = number
   default     = 0.2
 }
+
+variable "failure_rate_duration" {
+  description = "duration for condition to be active before alerting"
+  type        = number
+  default     = 120
+}


### PR DESCRIPTION
this can be adjusted for staging where we can set a higher value to avoid false positives, 
while keeping it low for prod to ensure prompt response