### PR TITLE
set alert document subject to include service name

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -226,6 +226,8 @@ resource "google_monitoring_alert_policy" "service_failure_rate" {
   display_name = "5xx failure rate above ${var.failure_rate_ratio_threshold}"
 
   documentation {
+    subject = "Cloud Run service $${resource.labels.service_name} had 5xx error rate above ${var.failure_rate_ratio_threshold} for ${var.failure_rate_duration}s"
+
     content = <<-EOT
     Please consult the playbook entry [here](https://wiki.inky.wtf/docs/teams/engineering/enforce/playbooks/5xx/) for troubleshooting information.
     EOT


### PR DESCRIPTION
the default subject for promql alerts does not include any labels

set custom subject to include service name to make it clear what it is alerting on.


following the example from https://github.com/hashicorp/terraform-provider-google/issues/16419