### PR TITLE
add filter for failed request alert

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -259,6 +259,7 @@ resource "google_monitoring_alert_policy" "cloud-run-scaling-failure" {
         log_name="projects/prod-enforce-fabc/logs/run.googleapis.com%2Frequests"
         severity=ERROR
         textPayload:"The request was aborted because there was no available instance."
+        ${var.scaling_issue_filter}
       EOT
 
       label_extractors = {
@@ -296,6 +297,7 @@ resource "google_monitoring_alert_policy" "cloud-run-failed-req" {
         log_name="projects/prod-enforce-fabc/logs/run.googleapis.com%2Frequests"
         severity=ERROR
         textPayload:"The request failed because either the HTTP response was malformed or connection to the instance had an error."
+        ${var.failed_req_filter}
       EOT
 
       label_extractors = {

--- a/modules/alerting/variables.tf
+++ b/modules/alerting/variables.tf
@@ -31,6 +31,16 @@ variable "oom_filter" {
   type        = string
 }
 
+variable "failed_req_filter" {
+  description = "additional filter to apply to failed request alert policy"
+  type        = string
+}
+
+variable "scaling_issue_filter" {
+  description = "additional filter to apply to scaling issue alert policy"
+  type        = string
+}
+
 variable "failure_rate_ratio_threshold" {
   description = "ratio threshold to alert for cloud run server failure rate."
   type        = number


### PR DESCRIPTION
this allows filtering out known problematic services like `ing-vuln`

will set the filter in mono to filter out `ing-vuln` like https://github.com/chainguard-dev/mono/blob/main/env/enforce.dev/iac/999-monitoring/cloudrun.tf#L339