### PR TITLE
octo-sts-secret: New terraform module for rotating GitHub tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.5.0
 	cloud.google.com/go/profiler v0.4.1
 	cloud.google.com/go/pubsub v1.40.0
+	cloud.google.com/go/secretmanager v1.13.3
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.0
 	github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270
 	github.com/chainguard-dev/clog v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ cloud.google.com/go/profiler v0.4.1 h1:Q7+lOvikTGMJ/IAWocpYYGit4SIIoILmVZfEEWTOR
 cloud.google.com/go/profiler v0.4.1/go.mod h1:LBrtEX6nbvhv1w/e5CPZmX9ajGG9BGLtGbv56Tg4SHs=
 cloud.google.com/go/pubsub v1.37.0-beta.otel.trace2 h1:L4riX1KnYBvcd/klUcSN2J3IP8CwG/GUOwM+m/PKafk=
 cloud.google.com/go/pubsub v1.37.0-beta.otel.trace2/go.mod h1:w0/SojkGQHyr45Ixf1oOAIUELRArOWpl6/r2yf+wibk=
+cloud.google.com/go/secretmanager v1.13.3 h1:VqUVYY3U6uFXOhPdZgAoZH9m8E6p7eK02TsDRj2SBf4=
+cloud.google.com/go/secretmanager v1.13.3/go.mod h1:e45+CxK0w6GaL4hS+KabgQskl4RdSS30b+HRf0TH0kk=
 cloud.google.com/go/storage v1.42.0 h1:4QtGpplCVt1wz6g5o1ifXd656P5z+yNgzdw1tVfp0cU=
 cloud.google.com/go/storage v1.42.0/go.mod h1:HjMXRFq65pGKFn6hxj6x3HCyR41uSB72Z0SO/Vn6JFQ=
 cloud.google.com/go/trace v1.10.9 h1:Cy6D1Zdz8up4mIPUWModTuIGDr3fh7AZaCnR+uyxpgA=

--- a/modules/octo-sts-secret/README.md
+++ b/modules/octo-sts-secret/README.md
@@ -1,0 +1,75 @@
+# `octo-sts-secret`
+
+This module sets up a Cloud Secret with a GitHub token obtained from [octo-sts](https://github.com/octo-sts/app). This module is particularly useful when a native Google Cloud service requires a GitHub token to be provided in a Cloud Secret
+
+The intended usage of this module:
+
+```hcl
+// Create a GitHub token rotated by octo-sts
+module "gh-secret" {
+  source  = "chainguard-dev/common/infra//modules/octo-sts-secret"
+
+  name       = "my-secret"
+  project_id = var.project_id
+  region     = var.primary-region
+
+  # The name of the GitHub org on which the secret will be scoped.
+	github_org = "my-org"
+  # The name of the GitHub repo on which the secret will be scoped.
+	github_repo = "my-repo"
+  # The name of the octo-sts policy.
+	octosts_policy = "my-policy"
+
+  # What the service accessing this secret will run as.
+  service-account = google_service_account.foo.email
+
+  # Optionally: channels to notify if this secret is manipulated.
+  notification-channels = [ ... ]
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gh-token-secret"></a> [gh-token-secret](#module\_gh-token-secret) | ../secret | n/a |
+| <a name="module_this"></a> [this](#module\_this) | ../cron | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_secret_manager_secret_iam_binding.authorize-manage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_binding) | resource |
+| [google_service_account.octo-sts-rotator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_github_org"></a> [github\_org](#input\_github\_org) | The GitHub organization for which the octo-sts token will be requested. | `string` | n/a | yes |
+| <a name="input_github_repo"></a> [github\_repo](#input\_github\_repo) | The GitHub repository for which the octo-sts token will be requested. | `string` | n/a | yes |
+| <a name="input_invokers"></a> [invokers](#input\_invokers) | List of user emails to grant invoker perimssions to invoke the job. | `list(string)` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name to give the secret. | `string` | n/a | yes |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
+| <a name="input_octosts_policy"></a> [octosts\_policy](#input\_octosts\_policy) | The name of the octo-sts policy for which to request a token. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region to run the job. | `string` | `"us-east4"` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | The email of the service account that will access the secret. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | The ID of the secret. |
+<!-- END_TF_DOCS -->

--- a/modules/octo-sts-secret/cmd/rotate/main.go
+++ b/modules/octo-sts-secret/cmd/rotate/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"

--- a/modules/octo-sts-secret/cmd/rotate/main.go
+++ b/modules/octo-sts-secret/cmd/rotate/main.go
@@ -34,7 +34,7 @@ func main() {
 		panic(fmt.Errorf("failed to parse env: %w", err))
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	c, err := secretmanager.NewClient(ctx)

--- a/modules/octo-sts-secret/cmd/rotate/main.go
+++ b/modules/octo-sts-secret/cmd/rotate/main.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/chainguard-dev/clog"
+	"github.com/kelseyhightower/envconfig"
+	"google.golang.org/api/iterator"
+
+	"github.com/chainguard-dev/terraform-infra-common/pkg/octosts"
+)
+
+type envConfig struct {
+	OctoSTSPolicy     string `envconfig:"OCTOSTS_POLICY" required:"true"`
+	GitHubOrg         string `envconfig:"GITHUB_ORG" required:"true"`
+	GitHubRepo        string `envconfig:"GITHUB_REPO" required:"true"`
+	GitHubTokenSecret string `envconfig:"GITHUB_TOKEN_SECRET" required:"true"`
+}
+
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		panic(fmt.Errorf("failed to parse env: %w", err))
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	c, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		clog.FatalContextf(ctx, "failed to create gcp secret client: %v", err)
+	}
+
+	token, err := octosts.Token(ctx, env.OctoSTSPolicy, env.GitHubOrg, env.GitHubRepo)
+	if err != nil {
+		clog.FromContext(ctx).Fatal("failed to get octosts token: %w", err)
+	}
+
+	// Add a new secret version with the new token.
+	createdSecretVersion, err := c.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent: env.GitHubTokenSecret,
+		Payload: &secretmanagerpb.SecretPayload{
+			Data: []byte(token),
+		},
+	})
+	if err != nil {
+		clog.FatalContextf(ctx, "failed to add secret version: %v", err)
+	}
+	clog.FromContext(ctx).Info("successfully rotated the GitHub token")
+
+	// Destroy older secret versions.
+	it := c.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
+		Parent: env.GitHubTokenSecret,
+		Filter: "state:ENABLED",
+	})
+	for {
+		version, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			clog.FatalContextf(ctx, "failed to list secret versions: %v", err)
+		}
+
+		if version.Name == createdSecretVersion.Name {
+			// Don't delete the newly created secret version.
+			continue
+		}
+
+		if _, err := c.DestroySecretVersion(ctx, &secretmanagerpb.DestroySecretVersionRequest{
+			Name: version.Name,
+		}); err != nil {
+			clog.FatalContextf(ctx, "failed to destroy secret version: %v", err)
+		}
+	}
+	clog.FromContext(ctx).Info("successfully deleted older secret versions")
+}

--- a/modules/octo-sts-secret/main.tf
+++ b/modules/octo-sts-secret/main.tf
@@ -1,0 +1,55 @@
+// Create a dedicated GSA for the rotating GitHub tokens.
+resource "google_service_account" "octo-sts-rotator" {
+  project = var.project_id
+
+  account_id   = var.name
+  display_name = "Octo STS Secret Rotator"
+  description  = "Dedicated service account for rotating the Octo STS token for ${var.name}"
+}
+
+module "gh-token-secret" {
+  source = "../secret"
+
+  project_id = var.project_id
+  name       = var.name
+
+  service-account  = var.service_account
+  authorized-adder = "serviceAccount:${google_service_account.octo-sts-rotator.email}"
+
+  notification-channels = var.notification_channels
+}
+
+// The cron rotation job needs to list & delete access to cleanup old secrets.
+resource "google_secret_manager_secret_iam_binding" "authorize-manage" {
+  secret_id = module.gh-token-secret.secret_id
+  role      = "roles/secretmanager.secretVersionManager"
+  members   = ["serviceAccount:${google_service_account.octo-sts-rotator.email}"]
+}
+
+module "this" {
+  source = "../cron"
+
+  name       = var.name
+  project_id = var.project_id
+  region     = var.region
+
+  invokers = var.invokers
+
+  timeout = "60s" // 1 minute
+  # Run every 30 minutes
+  schedule = "*/30 * * * *"
+
+  working_dir = path.module
+  importpath  = "./cmd/rotate"
+
+  service_account = google_service_account.octo-sts-rotator.email
+
+  env = {
+    GITHUB_ORG          = var.github_org
+    GITHUB_REPO         = var.github_repo
+    OCTOSTS_POLICY      = var.octosts_policy
+    GITHUB_TOKEN_SECRET = module.gh-token-secret.secret_id
+  }
+
+  notification_channels = var.notification_channels
+}

--- a/modules/octo-sts-secret/main.tf
+++ b/modules/octo-sts-secret/main.tf
@@ -37,7 +37,7 @@ module "this" {
 
   timeout = "60s" // 1 minute
   # Run every 30 minutes
-  schedule = "*/30 * * * *"
+  schedule = "17-59/30 * * * *"
 
   working_dir = path.module
   importpath  = "./cmd/rotate"

--- a/modules/octo-sts-secret/main.tf
+++ b/modules/octo-sts-secret/main.tf
@@ -33,8 +33,6 @@ module "this" {
   project_id = var.project_id
   region     = var.region
 
-  invokers = var.invokers
-
   timeout = "60s" // 1 minute
   # Run every 30 minutes
   schedule = "17-59/30 * * * *"
@@ -51,5 +49,12 @@ module "this" {
     GITHUB_TOKEN_SECRET = module.gh-token-secret.secret_id
   }
 
+  notification_channels = var.notification_channels
+}
+
+module "dashboard" {
+  source       = "../dashboard/job"
+  job_name = module.this.name
+  project_id = var.project_id
   notification_channels = var.notification_channels
 }

--- a/modules/octo-sts-secret/outputs.tf
+++ b/modules/octo-sts-secret/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_id" {
+  description = "The ID of the secret."
+  value       = module.gh-token-secret.secret_id
+}

--- a/modules/octo-sts-secret/variables.tf
+++ b/modules/octo-sts-secret/variables.tf
@@ -1,0 +1,44 @@
+variable "project_id" {
+  type = string
+}
+
+variable "name" {
+  description = "The name to give the secret."
+  type        = string
+}
+
+variable "service_account" {
+  description = "The email of the service account that will access the secret."
+  type        = string
+}
+
+variable "region" {
+  default     = "us-east4"
+  description = "The region to run the job."
+}
+
+variable "invokers" {
+  description = "List of user emails to grant invoker perimssions to invoke the job."
+  type        = list(string)
+  default     = []
+}
+
+variable "github_org" {
+  description = "The GitHub organization for which the octo-sts token will be requested."
+  type        = string
+}
+
+variable "github_repo" {
+  description = "The GitHub repository for which the octo-sts token will be requested."
+  type        = string
+}
+
+variable "octosts_policy" {
+  description = "The name of the octo-sts policy for which to request a token."
+  type        = string
+}
+
+variable "notification_channels" {
+  description = "List of notification channels to alert."
+  type        = list(string)
+}

--- a/modules/octo-sts-secret/variables.tf
+++ b/modules/octo-sts-secret/variables.tf
@@ -17,12 +17,6 @@ variable "region" {
   description = "The region to run the job."
 }
 
-variable "invokers" {
-  description = "List of user emails to grant invoker perimssions to invoke the job."
-  type        = list(string)
-  default     = []
-}
-
 variable "github_org" {
   description = "The GitHub organization for which the octo-sts token will be requested."
   type        = string


### PR DESCRIPTION
This module allows to store an octo-sts token in a Google Cloud Secret in order to:

1. Allow a Google Cloud service to access a GitHub repo (Google Cloud Build, Google Cloud Dataform)
2. (not recommended) Share a cached GitHub secret between services

The main use case is (1) - but it also makes (2) possible if really needed.