### PR TITLE
fix variable reference in alert subject

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -226,7 +226,8 @@ resource "google_monitoring_alert_policy" "service_failure_rate" {
   display_name = "5xx failure rate above ${var.failure_rate_ratio_threshold}"
 
   documentation {
-    subject = "Cloud Run service $${resource.labels.service_name} had 5xx error rate above ${var.failure_rate_ratio_threshold} for ${var.failure_rate_duration}s"
+    // variables reference: https://cloud.google.com/monitoring/alerts/doc-variables#doc-vars
+    subject = "Cloud Run service $${resource.label.service_name} had 5xx error rate above ${var.failure_rate_ratio_threshold} for ${var.failure_rate_duration}s"
 
     content = <<-EOT
     Please consult the playbook entry [here](https://wiki.inky.wtf/docs/teams/engineering/enforce/playbooks/5xx/) for troubleshooting information.


### PR DESCRIPTION
add comment for subject variables reference

`resource.labels.service_name` => `resource.label.service_name` 
drop `s` on `label`