### PR TITLE
allow specifying raw filter to pubsub for github-bot/trigger

### DIFF
--- a/modules/cloudevent-trigger/README.md
+++ b/modules/cloudevent-trigger/README.md
@@ -128,6 +128,7 @@ No requirements.
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_private-service"></a> [private-service](#input\_private-service) | The private cloud run service that is subscribing to these events. | <pre>object({<br>    name   = string<br>    region = string<br>  })</pre> | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_raw_filter"></a> [raw\_filter](#input\_raw\_filter) | Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/cloudevent-trigger/main.tf
+++ b/modules/cloudevent-trigger/main.tf
@@ -105,7 +105,7 @@ resource "google_pubsub_subscription" "this" {
 
   ack_deadline_seconds = var.ack_deadline_seconds
 
-  filter = join(" AND ", local.filter-elements)
+  filter = var.raw_filter == "" ? join(" AND ", local.filter-elements) : var.raw_filter
 
   push_config {
     push_endpoint = module.authorize-delivery.uri

--- a/modules/cloudevent-trigger/variables.tf
+++ b/modules/cloudevent-trigger/variables.tf
@@ -11,6 +11,12 @@ variable "broker" {
   type        = string
 }
 
+variable "raw_filter" {
+  description = "Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax"
+  type        = string
+  default     = ""
+}
+
 variable "filter" {
   description = <<EOD
 A Knative Trigger-style filter over the cloud event attributes.

--- a/modules/github-bots/README.md
+++ b/modules/github-bots/README.md
@@ -117,6 +117,7 @@ No requirements.
 | <a name="input_name"></a> [name](#input\_name) | The name of the bot. | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
+| <a name="input_raw_filter"></a> [raw\_filter](#input\_raw\_filter) | Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax | `string` | `""` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork. | <pre>map(object({<br>    network = string<br>    subnet  = string<br>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -51,6 +51,7 @@ module "cloudevent-trigger" {
   project_id                = var.project_id
   name                      = "bot-trigger-${var.name}"
   broker                    = var.broker[each.key]
+  raw_filter                = var.raw_filter
   filter                    = local.combined_filter
   filter_prefix             = local.combined_filter_prefix
   filter_has_attributes     = local.combined_filter_has_attributes

--- a/modules/github-bots/variables.tf
+++ b/modules/github-bots/variables.tf
@@ -82,6 +82,12 @@ variable "notification_channels" {
   type        = list(string)
 }
 
+variable "raw_filter" {
+  description = "Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax"
+  type        = string
+  default     = ""
+}
+
 variable "extra_filter" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
the motivation for this is to be able to filter on two types of github events
rather than be restricted to the multiple variables, allow custom crafting the exact filter desired