### PR TITLE
validateResponse: check the if rate limit has been reached

### DIFF
--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -152,7 +152,7 @@ func (c GitHubClient) AddLabel(ctx context.Context, pr *github.PullRequest, labe
 
 	log.Infof("Adding label %q to PR %d", label, *pr.Number)
 	_, resp, err := c.inner.Issues.AddLabelsToIssue(ctx, *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *pr.Number, []string{label})
-	if err := validateResponse(err, resp, "add label to pull request"); err != nil {
+	if err := validateResponse(ctx, err, resp, "add label to pull request"); err != nil {
 		return err
 	}
 	return nil
@@ -169,7 +169,7 @@ func (c GitHubClient) RemoveLabel(ctx context.Context, pr *github.PullRequest, l
 
 	log.Infof("Removing label %q from PR %d", label, *pr.Number)
 	resp, err := c.inner.Issues.RemoveLabelForIssue(ctx, *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *pr.Number, label)
-	if err := validateResponse(err, resp, "remove label from pull request"); err != nil {
+	if err := validateResponse(ctx, err, resp, "remove label from pull request"); err != nil {
 		return err
 	}
 	return nil
@@ -188,7 +188,7 @@ func (c GitHubClient) SetComment(ctx context.Context, pr *github.PullRequest, bo
 			if _, resp, err := c.inner.Issues.EditComment(ctx, *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *com.ID, &github.IssueComment{
 				Body: &content,
 			}); err != nil || resp.StatusCode != 200 {
-				return validateResponse(err, resp, "editing comment")
+				return validateResponse(ctx, err, resp, "editing comment")
 			}
 			return nil
 		}
@@ -196,7 +196,7 @@ func (c GitHubClient) SetComment(ctx context.Context, pr *github.PullRequest, bo
 	if _, resp, err := c.inner.Issues.CreateComment(ctx, *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *pr.Number, &github.IssueComment{
 		Body: &content,
 	}); err != nil || resp.StatusCode != 201 {
-		return validateResponse(err, resp, "create comment")
+		return validateResponse(ctx, err, resp, "create comment")
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (c GitHubClient) AddComment(ctx context.Context, pr *github.PullRequest, co
 	if _, resp, err := c.inner.Issues.CreateComment(ctx, *pr.Base.Repo.Owner.Login, *pr.Base.Repo.Name, *pr.Number, &github.IssueComment{
 		Body: &content,
 	}); err != nil || resp.StatusCode != 201 {
-		return validateResponse(err, resp, "creating comment")
+		return validateResponse(ctx, err, resp, "creating comment")
 	}
 	return nil
 }
@@ -440,7 +440,7 @@ func (c GitHubClient) ListArtifactsFunc(ctx context.Context, wr *github.Workflow
 	return nil
 }
 
-func validateResponse(err error, resp *github.Response, action string) error {
+func validateResponse(ctx context.Context, err error, resp *github.Response, action string) error {
 	// resp may be nil if err is nonempty. However, err may contain a rate limit
 	// error so we have to inspect for rate limiting if resp is non-nil
 	if resp != nil {


### PR DESCRIPTION
I am getting some recent `context canceled` errors when adding/removing labels on PRs. I don't have much visibility on the rate limits. That is why I am adding this check to the response to have some visibility.

Logs:  https://cloudlogging.app.goo.gl/aWGt3MRtthPkubZF9