### PR TITLE
add missing label key for new log based metrics

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -301,6 +301,16 @@ resource "google_logging_metric" "cloud-run-scaling-failure" {
   metric_descriptor {
     metric_kind = "DELTA"
     value_type  = "INT64"
+    labels {
+      key         = "location"
+      value_type  = "STRING"
+      description = "location of service."
+    }
+    labels {
+      key         = "service_name"
+      value_type  = "STRING"
+      description = "name of service."
+    }
   }
 
   label_extractors = {
@@ -358,6 +368,16 @@ resource "google_logging_metric" "cloud-run-failed-req" {
   metric_descriptor {
     metric_kind = "DELTA"
     value_type  = "INT64"
+    labels {
+      key         = "location"
+      value_type  = "STRING"
+      description = "location of service."
+    }
+    labels {
+      key         = "service_name"
+      value_type  = "STRING"
+      description = "name of service."
+    }
   }
 
   label_extractors = {


### PR DESCRIPTION
```
│ Error: Error creating Metric: googleapi: Error 400: Number of label descriptors must match number of label extractors
│ 
│   with module.global-alert.google_logging_metric.cloud-run-scaling-failure,
│   on .terraform/modules/global-alert/modules/alerting/main.tf line 293, in resource "google_logging_metric" "cloud-run-scaling-failure":
│  293: resource "google_logging_metric" "cloud-run-scaling-failure" {
│ 
╵
╷
│ Error: Error creating Metric: googleapi: Error 400: Number of label descriptors must match number of label extractors
│ 
│   with module.global-alert.google_logging_metric.cloud-run-failed-req,
│   on .terraform/modules/global-alert/modules/alerting/main.tf line 350, in resource "google_logging_metric" "cloud-run-failed-req":
│  350: resource "google_logging_metric" "cloud-run-failed-req" {
```