### PR TITLE
explicitly set project for cloud run job resource

### DIFF
--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -32,6 +32,7 @@ resource "ko_build" "image" {
 
 resource "google_cloud_run_v2_job" "job" {
   provider = google-beta
+  project  = var.project_id
 
   name     = "${var.name}-cron"
   location = var.region


### PR DESCRIPTION
this is to avoid getting errors like

```
│ Error: Failed to retrieve project, pid: , err: project: required field is not set
│ 
│   with module.build.module.job["enterprise"].module.elastic-build-job.google_cloud_run_v2_job.job,
│   on .terraform/modules/build.job.elastic-build-job/modules/cron/main.tf line 33, in resource "google_cloud_run_v2_job" "job":
│   33: resource "google_cloud_run_v2_job" "job" {
```