### PR TITLE
metrics sidecar for cloudrun job

### DIFF
--- a/modules/cron/README.md
+++ b/modules/cron/README.md
@@ -109,6 +109,7 @@ No modules.
 | <a name="input_memory"></a> [memory](#input\_memory) | The memory limit for the job. | `string` | `"512Mi"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix to created resources. | `any` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | List of notification channels to alert. | `list(string)` | n/a | yes |
+| <a name="input_otel_collector_image"></a> [otel\_collector\_image](#input\_otel\_collector\_image) | The otel collector image to use as a base. Must be on gcr.io or dockerhub. | `string` | `"chainguard/opentelemetry-collector-contrib:latest"` | no |
 | <a name="input_paused"></a> [paused](#input\_paused) | Whether the cron scheduler is paused or not. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project that will host the cron job. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to run the job. | `string` | `"us-east4"` | no |

--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -132,6 +132,15 @@ resource "google_cloud_run_v2_job" "job" {
           }
         }
       }
+      containers {
+        image = var.otel_collector_image
+        // config via env is an option; https://pkg.go.dev/go.opentelemetry.io/collector/service#section-readme
+        args = ["--config=env:OTEL_CONFIG"]
+        env {
+          name  = "OTEL_CONFIG"
+          value = file("${path.module}/otel-config/config.yaml")
+        }
+      }
 
       dynamic "vpc_access" {
         for_each = var.vpc_access[*]

--- a/modules/cron/otel-config/config.yaml
+++ b/modules/cron/otel-config/config.yaml
@@ -1,0 +1,83 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: "localhost"
+        scrape_interval: 10s
+        static_configs:
+        # TODO: make this configurable
+        - targets: ["localhost:2112"]
+        # Do not relabel job and instance labels if existed.
+        honor_labels: true
+        metric_relabel_configs:
+          - source_labels: [ __name__ ]
+            regex: '^prometheus_.*'
+            action: drop
+          - source_labels: [ __name__ ]
+            regex: '^process_.*'
+            action: drop
+          - source_labels: [ __name__ ]
+            regex: '^go_.*'
+            action: drop
+
+processors:
+  batch:
+    # batch metrics before sending to reduce API usage
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 5s
+
+  memory_limiter:
+    # drop metrics if memory usage gets too high
+    check_interval: 1s
+    limit_percentage: 65
+    spike_limit_percentage: 20
+
+  # automatically detect Cloud Run resource metadata
+  resourcedetection:
+    detectors: [env, gcp]
+
+  resource:
+    attributes:
+    # Add instance_id as a resource attribute, so to avoid race conditions
+    # between multiple otel sidecar instance uploading overlapping time series
+    # to the same buckets.
+    - key: service.instance.id
+      from_attribute: faas.id
+      action: upsert
+    # The `gcp` resourcedetection processor sets `faas.name` to the name of the
+    # Cloud Run service or the Cloud Run job.
+    - from_attribute: faas.name
+      # The googlemanagedprometheus exporter consumes `service.name` attribute
+      # and set the `job` resource label to this value. (See
+      # https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/764)
+      key: "service.name"
+      action: upsert
+
+exporters:
+  googlemanagedprometheus:
+    sending_queue:
+      enabled: true
+      # we are handling metrics for a single pod, no need to have
+      # too many senders. this will also avoid out-of-order data.
+      num_consumers: 1
+
+extensions:
+  health_check:
+
+service:
+  telemetry:
+    logs:
+      # We don't want to see scraper startup logging every
+      # cold start.
+      level: "error"
+      # Stack trace is less useful and break lines.
+      disable_stacktrace: true
+      encoding: json
+
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch, memory_limiter, resourcedetection, resource]
+      exporters: [googlemanagedprometheus]

--- a/modules/cron/variables.tf
+++ b/modules/cron/variables.tf
@@ -160,3 +160,9 @@ variable "success_alert_alignment_period_seconds" {
   type        = number
   default     = 0
 }
+
+variable "otel_collector_image" {
+  type        = string
+  default     = "chainguard/opentelemetry-collector-contrib:latest"
+  description = "The otel collector image to use as a base. Must be on gcr.io or dockerhub."
+}


### PR DESCRIPTION
prometheus metrics are scrapped
otel sidecar does scrapping for prometheus metrics and push to gcp

still need to verify if it works
but i did verify that it doesnt break things

![Screenshot 2024-08-06 at 2 23 05 PM](https://github.com/user-attachments/assets/1db5c746-a694-4864-a5d2-7c6fc7f0610b)
