### PR TITLE
gh bots: add action and subject to event message

### DIFF
--- a/modules/cloudevent-recorder/cmd/recorder/main.go
+++ b/modules/cloudevent-recorder/cmd/recorder/main.go
@@ -45,7 +45,7 @@ func main() {
 	if err != nil {
 		clog.Fatalf("failed to create event client, %v", err)
 	}
-	if err := c.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) error {
+	if err := c.StartReceiver(ctx, func(_ context.Context, event cloudevents.Event) error {
 		dir := filepath.Join(env.LogPath, event.Type())
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -24,6 +24,7 @@ type contextKey string
 const (
 	ContextKeyAttributes contextKey = "ce-attributes"
 	ContextKeyType       contextKey = "ce-type"
+	ContextKeySubject    contextKey = "ce-subject"
 )
 
 type Bot struct {
@@ -98,7 +99,9 @@ func Serve(b Bot) {
 			}
 		}()
 
-		logger.Debug("handling event", "type", event.Type())
+		logger.With("type", event.Type(),
+			"subject", event.Subject(),
+			"action", event.Extensions()["action"]).Debug("handling event")
 
 		// dispatch event to n handlers
 		if handler, ok := b.Handlers[EventType(event.Type())]; ok {
@@ -110,6 +113,7 @@ func Serve(b Bot) {
 			// add existing event attributes to context so they can be used by the handlers
 			ctx = context.WithValue(ctx, ContextKeyAttributes, event.Extensions())
 			ctx = context.WithValue(ctx, ContextKeyType, event.Type())
+			ctx = context.WithValue(ctx, ContextKeySubject, event.Subject())
 
 			switch h := handler.(type) {
 			case WorkflowRunArtifactHandler:

--- a/pkg/httpmetrics/metrics_test.go
+++ b/pkg/httpmetrics/metrics_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestServerMetrics(t *testing.T) {
 	handler := "test"
-	http.Handle("/", Handler(handler, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	http.Handle("/", Handler(handler, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})))
 	srv := httptest.NewServer(http.DefaultServeMux)

--- a/pkg/httpmetrics/transport_test.go
+++ b/pkg/httpmetrics/transport_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTransport(t *testing.T) {
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		t.Log("got request")
 	}))
 	defer s.Close()


### PR DESCRIPTION
This should let subscribers filter on only repos they care about, and only actions they care about (e.g., PR opened but not closed, etc.)

Also clean up some lint findings.