### PR TITLE
bot sdk: configure log level with env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/go-github/v61 v61.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.19.1
+	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/snabb/httpreaderat v1.0.1
 	go.opentelemetry.io/contrib/detectors/gcp v1.28.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sethvargo/go-envconfig v1.1.0 h1:cWZiJxeTm7AlCvzGXrEXaSTCNgip5oJepekh/BOQuog=
+github.com/sethvargo/go-envconfig v1.1.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -14,7 +14,7 @@ import (
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/go-github/v61/github"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 )
 
 // Define a type for keys used in context to prevent key collisions.
@@ -61,18 +61,17 @@ func (b *Bot) RegisterHandler(handler EventHandlerFunc) {
 	b.Handlers[etype] = handler
 }
 
+var env = envconfig.MustProcess(context.Background(), struct {
+	Port     int        `envconfig:"PORT" default:"8080" required:"true"`
+	LogLevel slog.Level `envconfig:"LOG_LEVEL" default:"INFO"`
+}{})
+
 func Serve(b Bot) {
-	var env struct {
-		Port int `envconfig:"PORT" default:"8080" required:"true"`
-	}
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
-	}
 	ctx := context.Background()
 
-	slog.SetDefault(slog.New(gcp.NewHandler(slog.LevelInfo)))
+	slog.SetDefault(slog.New(gcp.NewHandler(env.LogLevel)))
 
-	logger := clog.FromContext(ctx)
+	log := clog.FromContext(ctx)
 
 	http.DefaultTransport = httpmetrics.Transport
 	go httpmetrics.ServeMetrics()
@@ -89,7 +88,7 @@ func Serve(b Bot) {
 		clog.Fatalf("failed to create event client, %v", err)
 	}
 
-	logger.Infof("starting bot %s receiver on port %d", b.Name, env.Port)
+	log.Infof("starting bot %s receiver on port %d", b.Name, env.Port)
 	if err := c.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) error {
 		clog.FromContext(ctx).With("event", event).Debugf("received event")
 
@@ -99,7 +98,7 @@ func Serve(b Bot) {
 			}
 		}()
 
-		logger.With("type", event.Type(),
+		log.With("type", event.Type(),
 			"subject", event.Subject(),
 			"action", event.Extensions()["action"]).Debug("handling event")
 
@@ -117,91 +116,91 @@ func Serve(b Bot) {
 
 			switch h := handler.(type) {
 			case WorkflowRunArtifactHandler:
-				logger.Debug("handling workflow run artifact event")
+				log.Debug("handling workflow run artifact event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run event: %v", err)
+					log.Errorf("failed to unmarshal workflow run event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run event: %v", err)
+					log.Errorf("failed to handle workflow run event: %v", err)
 					return err
 				}
 				return nil
 
 			case WorkflowRunHandler:
-				logger.Debug("handling workflow run event")
+				log.Debug("handling workflow run event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run event: %v", err)
+					log.Errorf("failed to unmarshal workflow run event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run event: %v", err)
+					log.Errorf("failed to handle workflow run event: %v", err)
 					return err
 				}
 				return nil
 
 			case WorkflowRunLogsHandler:
-				logger.Debug("handling workflow run logs event")
+				log.Debug("handling workflow run logs event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run with logs event: %v", err)
+					log.Errorf("failed to unmarshal workflow run with logs event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run with logs event: %v", err)
+					log.Errorf("failed to handle workflow run with logs event: %v", err)
 					return err
 				}
 				return nil
 
 			case PullRequestHandler:
-				logger.Debug("handling pull request event")
+				log.Debug("handling pull request event")
 
 				var pre schemas.Wrapper[github.PullRequestEvent]
 				if err := event.DataAs(&pre); err != nil {
-					logger.Errorf("failed to unmarshal pull request event: %v", err)
+					log.Errorf("failed to unmarshal pull request event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, pre.Body); err != nil {
-					logger.Errorf("failed to handle pull request event: %v", err)
+					log.Errorf("failed to handle pull request event: %v", err)
 					return err
 				}
 				return nil
 
 			case IssueCommentHandler:
-				logger.Debug("handling issue comment event")
+				log.Debug("handling issue comment event")
 
 				var ice schemas.Wrapper[github.IssueCommentEvent]
 				if err := event.DataAs(&ice); err != nil {
-					logger.Errorf("failed to unmarshal issue comment event: %v", err)
+					log.Errorf("failed to unmarshal issue comment event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, ice.Body); err != nil {
-					logger.Errorf("failed to handle issue comment event: %v", err)
+					log.Errorf("failed to handle issue comment event: %v", err)
 					return err
 				}
 				return nil
 
 			case PushHandler:
-				logger.Debug("handling push event")
+				log.Debug("handling push event")
 
 				var pe schemas.Wrapper[github.PushEvent]
 				if err := event.DataAs(&pe); err != nil {
-					logger.Errorf("failed to unmarshal push event: %v", err)
+					log.Errorf("failed to unmarshal push event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, pe.Body); err != nil {
-					logger.Errorf("failed to handle push event: %v", err)
+					log.Errorf("failed to handle push event: %v", err)
 					return err
 				}
 				return nil


### PR DESCRIPTION
This lets us configure the log level via env var, in case we want to start getting debug logs without rebuilding the app.

edit: we won't need this at all in the bot SDK if we merge and pick up https://github.com/chainguard-dev/clog/pull/21