### PR TITLE
migrate to sethvargo/go-envconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v61 v61.0.0
-	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.19.1
+	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/snabb/httpreaderat v1.0.1
 	go.opentelemetry.io/contrib/detectors/gcp v1.28.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -79,6 +79,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sethvargo/go-envconfig v1.1.0 h1:cWZiJxeTm7AlCvzGXrEXaSTCNgip5oJepekh/BOQuog=
+github.com/sethvargo/go-envconfig v1.1.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=

--- a/modules/bucket-events/cmd/trampoline/main.go
+++ b/modules/bucket-events/cmd/trampoline/main.go
@@ -20,15 +20,14 @@ import (
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/sethvargo/go-envconfig"
 	"google.golang.org/api/storage/v1"
-
-	"github.com/kelseyhightower/envconfig"
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Port       int    `envconfig:"PORT" default:"8080" required:"true"`
 	IngressURI string `envconfig:"INGRESS_URI" required:"true"`
-}
+}{})
 
 var eventTypes = map[string]string{
 	"OBJECT_FINALIZE":        "dev.chainguard.storage.object.finalize",
@@ -38,11 +37,6 @@ var eventTypes = map[string]string{
 }
 
 func main() {
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 

--- a/modules/bucket-events/cmd/trampoline/main.go
+++ b/modules/bucket-events/cmd/trampoline/main.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/api/storage/v1"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Port       int    `envconfig:"PORT" default:"8080" required:"true"`
 	IngressURI string `envconfig:"INGRESS_URI" required:"true"`
 }{})

--- a/modules/cloudevent-broker/cmd/ingress/main.go
+++ b/modules/cloudevent-broker/cmd/ingress/main.go
@@ -19,7 +19,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -36,21 +36,16 @@ const (
 	maxRetry   = 3
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Port  int    `envconfig:"PORT" default:"8080" required:"true"`
 	Topic string `envconfig:"PUBSUB_TOPIC" required:"true"`
-}
+}{})
 
 func main() {
 	profiler.SetupProfiler()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
-	}
 
 	go httpmetrics.ServeMetrics()
 	defer httpmetrics.SetupTracer(ctx)()

--- a/modules/cloudevent-broker/cmd/ingress/main.go
+++ b/modules/cloudevent-broker/cmd/ingress/main.go
@@ -36,7 +36,7 @@ const (
 	maxRetry   = 3
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Port  int    `envconfig:"PORT" default:"8080" required:"true"`
 	Topic string `envconfig:"PUBSUB_TOPIC" required:"true"`
 }{})

--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -24,7 +24,7 @@ const (
 	maxRetry   = 3
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Host string `envconfig:"HOST" default:"http://0.0.0.0" required:"true"`
 	Port int    `envconfig:"PORT" default:"8080" required:"true"`
 

--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 	"google.golang.org/api/iterator"
 )
 
@@ -24,7 +24,7 @@ const (
 	maxRetry   = 3
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Host string `envconfig:"HOST" default:"http://0.0.0.0" required:"true"`
 	Port int    `envconfig:"PORT" default:"8080" required:"true"`
 
@@ -36,9 +36,9 @@ type envConfig struct {
 
 	// QueryWindow is the window to look for release failures
 	Query string `envconfig:"QUERY" required:"true"`
-}
+}{})
 
-func Publish(ctx context.Context, env envConfig, event cloudevents.Event) error {
+func Publish(ctx context.Context, event cloudevents.Event) error {
 	// TODO: Add idtoken back?
 	ceclient, err := cloudevents.NewClientHTTP(
 		cloudevents.WithTarget(fmt.Sprintf("%s:%d", env.Host, env.Port)),
@@ -57,12 +57,6 @@ func Publish(ctx context.Context, env envConfig, event cloudevents.Event) error 
 }
 
 func main() {
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Errorf("failed to process env var: %s", err)
-		return
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	log := clog.FromContext(ctx)
@@ -121,7 +115,7 @@ func main() {
 
 		// TODO: Time based publishing if we care about replaying using the
 		// timestamps in the dataset
-		if err := Publish(ctx, env, event); err != nil {
+		if err := Publish(ctx, event); err != nil {
 			log.Errorf("Publishing event: %v", err)
 			// Try to process next events
 		}

--- a/modules/cloudevent-recorder/cmd/logrotate/main.go
+++ b/modules/cloudevent-recorder/cmd/logrotate/main.go
@@ -19,7 +19,7 @@ import (
 	"syscall"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Bucket        string        `envconfig:"BUCKET" required:"true"`
 	FlushInterval time.Duration `envconfig:"FLUSH_INTERVAL" default:"3m"`
 	LogPath       string        `envconfig:"LOG_PATH" required:"true"`

--- a/modules/cloudevent-recorder/cmd/logrotate/main.go
+++ b/modules/cloudevent-recorder/cmd/logrotate/main.go
@@ -14,24 +14,19 @@ import (
 	"github.com/chainguard-dev/clog"
 	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/rotate"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 
 	"syscall"
 )
 
-type rotateConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Bucket        string        `envconfig:"BUCKET" required:"true"`
 	FlushInterval time.Duration `envconfig:"FLUSH_INTERVAL" default:"3m"`
 	LogPath       string        `envconfig:"LOG_PATH" required:"true"`
-}
+}{})
 
 func main() {
-	var rc rotateConfig
-	if err := envconfig.Process("", &rc); err != nil {
-		clog.Fatalf("Error processing environment: %v", err)
-	}
-
-	uploader := rotate.NewUploader(rc.LogPath, rc.Bucket, rc.FlushInterval)
+	uploader := rotate.NewUploader(env.LogPath, env.Bucket, env.FlushInterval)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()

--- a/modules/cloudevent-recorder/cmd/recorder/main.go
+++ b/modules/cloudevent-recorder/cmd/recorder/main.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 
 	"github.com/chainguard-dev/clog"
 	_ "github.com/chainguard-dev/clog/gcp/init"
@@ -22,18 +22,13 @@ import (
 	"github.com/chainguard-dev/terraform-infra-common/pkg/profiler"
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Port    int    `envconfig:"PORT" default:"8080" required:"true"`
 	LogPath string `envconfig:"LOG_PATH" required:"true"`
-}
+}{})
 
 func main() {
 	profiler.SetupProfiler()
-
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %v", err)
-	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()

--- a/modules/cloudevent-recorder/cmd/recorder/main.go
+++ b/modules/cloudevent-recorder/cmd/recorder/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/chainguard-dev/terraform-infra-common/pkg/profiler"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Port    int    `envconfig:"PORT" default:"8080" required:"true"`
 	LogPath string `envconfig:"LOG_PATH" required:"true"`
 }{})

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -14,7 +14,7 @@ import (
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/go-github/v61/github"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 )
 
 // Define a type for keys used in context to prevent key collisions.

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -60,7 +60,7 @@ func (b *Bot) RegisterHandler(handler EventHandlerFunc) {
 	b.Handlers[etype] = handler
 }
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Port int `envconfig:"PORT" default:"8080" required:"true"`
 }{})
 

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -7,7 +7,7 @@ import (
 	"runtime/debug"
 
 	"github.com/chainguard-dev/clog"
-	_ "github.com/chainguard-dev/clog/gcp/init"
+	_ "github.com/chainguard-dev/clog/gcp/init" // enable GCP logging
 	"github.com/chainguard-dev/terraform-infra-common/modules/github-events/schemas"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"

--- a/modules/github-bots/sdk/bot.go
+++ b/modules/github-bots/sdk/bot.go
@@ -3,12 +3,11 @@ package sdk
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"runtime/debug"
 
 	"github.com/chainguard-dev/clog"
-	"github.com/chainguard-dev/clog/gcp"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/modules/github-events/schemas"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
@@ -61,18 +60,14 @@ func (b *Bot) RegisterHandler(handler EventHandlerFunc) {
 	b.Handlers[etype] = handler
 }
 
+var env = envconfig.MustProcess(context.Background(), struct {
+	Port int `envconfig:"PORT" default:"8080" required:"true"`
+}{})
+
 func Serve(b Bot) {
-	var env struct {
-		Port int `envconfig:"PORT" default:"8080" required:"true"`
-	}
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
-	}
 	ctx := context.Background()
 
-	slog.SetDefault(slog.New(gcp.NewHandler(slog.LevelInfo)))
-
-	logger := clog.FromContext(ctx)
+	log := clog.FromContext(ctx)
 
 	http.DefaultTransport = httpmetrics.Transport
 	go httpmetrics.ServeMetrics()
@@ -89,7 +84,7 @@ func Serve(b Bot) {
 		clog.Fatalf("failed to create event client, %v", err)
 	}
 
-	logger.Infof("starting bot %s receiver on port %d", b.Name, env.Port)
+	log.Infof("starting bot %s receiver on port %d", b.Name, env.Port)
 	if err := c.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) error {
 		clog.FromContext(ctx).With("event", event).Debugf("received event")
 
@@ -99,7 +94,7 @@ func Serve(b Bot) {
 			}
 		}()
 
-		logger.With("type", event.Type(),
+		log.With("type", event.Type(),
 			"subject", event.Subject(),
 			"action", event.Extensions()["action"]).Debug("handling event")
 
@@ -117,91 +112,91 @@ func Serve(b Bot) {
 
 			switch h := handler.(type) {
 			case WorkflowRunArtifactHandler:
-				logger.Debug("handling workflow run artifact event")
+				log.Debug("handling workflow run artifact event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run event: %v", err)
+					log.Errorf("failed to unmarshal workflow run event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run event: %v", err)
+					log.Errorf("failed to handle workflow run event: %v", err)
 					return err
 				}
 				return nil
 
 			case WorkflowRunHandler:
-				logger.Debug("handling workflow run event")
+				log.Debug("handling workflow run event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run event: %v", err)
+					log.Errorf("failed to unmarshal workflow run event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run event: %v", err)
+					log.Errorf("failed to handle workflow run event: %v", err)
 					return err
 				}
 				return nil
 
 			case WorkflowRunLogsHandler:
-				logger.Debug("handling workflow run logs event")
+				log.Debug("handling workflow run logs event")
 
 				var wre schemas.Wrapper[github.WorkflowRunEvent]
 				if err := event.DataAs(&wre); err != nil {
-					logger.Errorf("failed to unmarshal workflow run with logs event: %v", err)
+					log.Errorf("failed to unmarshal workflow run with logs event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, wre.Body); err != nil {
-					logger.Errorf("failed to handle workflow run with logs event: %v", err)
+					log.Errorf("failed to handle workflow run with logs event: %v", err)
 					return err
 				}
 				return nil
 
 			case PullRequestHandler:
-				logger.Debug("handling pull request event")
+				log.Debug("handling pull request event")
 
 				var pre schemas.Wrapper[github.PullRequestEvent]
 				if err := event.DataAs(&pre); err != nil {
-					logger.Errorf("failed to unmarshal pull request event: %v", err)
+					log.Errorf("failed to unmarshal pull request event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, pre.Body); err != nil {
-					logger.Errorf("failed to handle pull request event: %v", err)
+					log.Errorf("failed to handle pull request event: %v", err)
 					return err
 				}
 				return nil
 
 			case IssueCommentHandler:
-				logger.Debug("handling issue comment event")
+				log.Debug("handling issue comment event")
 
 				var ice schemas.Wrapper[github.IssueCommentEvent]
 				if err := event.DataAs(&ice); err != nil {
-					logger.Errorf("failed to unmarshal issue comment event: %v", err)
+					log.Errorf("failed to unmarshal issue comment event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, ice.Body); err != nil {
-					logger.Errorf("failed to handle issue comment event: %v", err)
+					log.Errorf("failed to handle issue comment event: %v", err)
 					return err
 				}
 				return nil
 
 			case PushHandler:
-				logger.Debug("handling push event")
+				log.Debug("handling push event")
 
 				var pe schemas.Wrapper[github.PushEvent]
 				if err := event.DataAs(&pe); err != nil {
-					logger.Errorf("failed to unmarshal push event: %v", err)
+					log.Errorf("failed to unmarshal push event: %v", err)
 					return err
 				}
 
 				if err := h(ctx, pe.Body); err != nil {
-					logger.Errorf("failed to handle push event: %v", err)
+					log.Errorf("failed to handle push event: %v", err)
 					return err
 				}
 				return nil

--- a/modules/github-events/cmd/trampoline/main.go
+++ b/modules/github-events/cmd/trampoline/main.go
@@ -21,21 +21,16 @@ import (
 	mce "github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics/cloudevents"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/go-github/v61/github"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	Port          int    `envconfig:"PORT" default:"8080" required:"true"`
 	IngressURI    string `envconfig:"EVENT_INGRESS_URI" required:"true"`
 	WebhookSecret string `envconfig:"WEBHOOK_SECRET" required:"true"`
-}
+}{})
 
 func main() {
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %s", err)
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 

--- a/modules/github-events/cmd/trampoline/main.go
+++ b/modules/github-events/cmd/trampoline/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sethvargo/go-envconfig"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	Port          int    `envconfig:"PORT" default:"8080" required:"true"`
 	IngressURI    string `envconfig:"EVENT_INGRESS_URI" required:"true"`
 	WebhookSecret string `envconfig:"WEBHOOK_SECRET" required:"true"`

--- a/pkg/httpmetrics/metrics.go
+++ b/pkg/httpmetrics/metrics.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	MetricsPort int `envconfig:"METRICS_PORT" default:"2112"`
 
 	// https://cloud.google.com/run/docs/container-contract#services-env-vars

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -6,24 +6,20 @@ SPDX-License-Identifier: Apache-2.0
 package profiler
 
 import (
+	"context"
 	"os"
 
 	"cloud.google.com/go/profiler"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/sethvargo/go-envconfig"
 
 	"github.com/chainguard-dev/clog"
 )
 
-type envConfig struct {
+var env = envconfig.MustProcess(context.Background(), struct {
 	EnableProfiler bool `envconfig:"ENABLE_PROFILER" default:"false" required:"false"`
-}
+}{})
 
 func SetupProfiler() {
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		clog.Fatalf("failed to process env var: %v", err)
-	}
-
 	if env.EnableProfiler {
 		if err := profiler.Start(profiler.Config{Service: os.Getenv("K_SERVICE")}); err != nil {
 			clog.Fatalf("failed to start profiler: %v", err)

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/chainguard-dev/clog"
 )
 
-var env = envconfig.MustProcess(context.Background(), struct {
+var env = envconfig.MustProcess(context.Background(), &struct {
 	EnableProfiler bool `envconfig:"ENABLE_PROFILER" default:"false" required:"false"`
 }{})
 


### PR DESCRIPTION
This seems to be more updated than kelseyhightower/envconfig, and it has a `MustProcess` that returns the value, meaning it can be used as an init-time package variable.