### PR TITLE
github-bots: remove trigger from the name to allow more custom chars

### DIFF
--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -49,7 +49,7 @@ module "cloudevent-trigger" {
   source   = "../cloudevent-trigger"
 
   project_id                = var.project_id
-  name                      = "bot-trigger-${var.name}"
+  name                      = "bot-${var.name}"
   broker                    = var.broker[each.key]
   raw_filter                = var.raw_filter
   filter                    = local.combined_filter


### PR DESCRIPTION
I tried creating a bot with a brief descriptive name, for example `my-team-update-check`  but got an error during the apply:

```
(""bot-trigger-my-team-update-check-bj0e") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
```

`bot-trigger-` is always added as a prefix, which makes it pretty easy to go over the 28 char regex restriction.

Could we remove the `trigger-` part?