### PR TITLE
github: Avoid redundant token reuse wrapper

### DIFF
--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -39,8 +39,19 @@ func NewGitHubClient(ctx context.Context, org, repo, policyName string) GitHubCl
 		policyName: policyName,
 		sometimes:  rate.Sometimes{Interval: 30 * time.Minute},
 	}
+
+	// Don't use oauth2.NewClient because it always wraps with oauth2.ReuseTokenSource,
+	// which doesn't work well with our auto-revoking octo token source, and we already
+	// reuse tokens ourselves.
+	hc := &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   http.DefaultClient.Transport,
+			Source: ts,
+		},
+	}
+
 	return GitHubClient{
-		inner: github.NewClient(oauth2.NewClient(ctx, ts)),
+		inner: github.NewClient(hc),
 		ts:    ts,
 		// TODO: Make this configurable?
 		bufSize: 1024 * 1024, // 1MB buffer for requests

--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -32,7 +32,7 @@ import (
 //
 // A new token is created for each client, and is not refreshed. It can be
 // revoked with Close.
-func NewGitHubClient(ctx context.Context, org, repo, policyName string) GitHubClient {
+func NewGitHubClient(_ context.Context, org, repo, policyName string) GitHubClient {
 	ts := &tokenSource{
 		org:        org,
 		repo:       repo,


### PR DESCRIPTION
Since we are doing our own token reuse and revocation, the wrapping done by oauth2.NewClient doesn't work, since it reuses tokens until they expire. Our tokens don't set an expiry, so they never expire.