### PR TITLE
regional-service: add labels to Cloud Run template

### DIFF
--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -64,6 +64,8 @@ resource "google_cloud_run_v2_service" "this" {
     }
     max_instance_request_concurrency = var.scaling.max_instance_request_concurrency
     execution_environment            = var.execution_environment
+    labels                           = merge(var.labels, local.default_labels)
+
     vpc_access {
       network_interfaces {
         network    = each.value.network


### PR DESCRIPTION
These are the labels that GCP billing will ingest into BQ, it ignores the labels at the metadata level.

gcp docs: https://cloud.google.com/run/docs/configuring/services/labels#terraform