### PR TITLE
pin google provider to less than 6

### DIFF
--- a/modules/serverless-gclb/README.md
+++ b/modules/serverless-gclb/README.md
@@ -68,13 +68,16 @@ module "serverless-gclb" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.79, < 6 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.79, < 6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.79, < 6 |
 
 ## Modules
 

--- a/modules/serverless-gclb/main.tf
+++ b/modules/serverless-gclb/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.79, < 6"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 4.79, < 6"
+    }
+  }
+}
+
 // Create the IP address for our LB to serve on.
 resource "google_compute_global_address" "this" {
   project = var.project_id
@@ -73,7 +86,6 @@ resource "google_compute_backend_service" "public-services" {
   dynamic "iap" {
     for_each = var.iap[*]
     content {
-      enabled              = true
       oauth2_client_id     = iap.value["oauth2_client_id"]
       oauth2_client_secret = iap.value["oauth2_client_secret"]
     }


### PR DESCRIPTION
google provider 6.x.x just came out today
and a lot of google modules havent been updated to support 6.x.x

our module with no version restrictions, defaulted to using the latest, which broke validation as it had breaking change

fixed it, but due to google modules not supporting it, we need to use 5.x.x for the time being
restrict the module to < 6.0.0 until all google modules support 6.x.x