### PR TITLE
tune down auto-close for logs based alerts

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -363,12 +363,12 @@ resource "google_logging_metric" "cloud-run-scaling-failure" {
 }
 
 resource "google_monitoring_alert_policy" "cloud-run-scaling-failure" {
-  # In the absence of data, incident will auto-close after an daily
+  # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"
 
     notification_rate_limit {
-      period = "3600s" // re-alert daily if condition still valid.
+      period = "3600s" // re-alert hourly if condition still valid.
     }
   }
 
@@ -430,12 +430,12 @@ resource "google_logging_metric" "cloud-run-failed-req" {
 }
 
 resource "google_monitoring_alert_policy" "cloud-run-failed-req" {
-  # In the absence of data, incident will auto-close after an daily
+  # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"
 
     notification_rate_limit {
-      period = "3600s" // re-alert daily if condition still valid.
+      period = "3600s" // re-alert hourly if condition still valid.
     }
   }
 

--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -365,10 +365,10 @@ resource "google_logging_metric" "cloud-run-scaling-failure" {
 resource "google_monitoring_alert_policy" "cloud-run-scaling-failure" {
   # In the absence of data, incident will auto-close after an daily
   alert_strategy {
-    auto_close = "86400s"
+    auto_close = "3600s"
 
     notification_rate_limit {
-      period = "86400s" // re-alert daily if condition still valid.
+      period = "3600s" // re-alert daily if condition still valid.
     }
   }
 
@@ -432,10 +432,10 @@ resource "google_logging_metric" "cloud-run-failed-req" {
 resource "google_monitoring_alert_policy" "cloud-run-failed-req" {
   # In the absence of data, incident will auto-close after an daily
   alert_strategy {
-    auto_close = "86400s"
+    auto_close = "3600s"
 
     notification_rate_limit {
-      period = "86400s" // re-alert daily if condition still valid.
+      period = "3600s" // re-alert daily if condition still valid.
     }
   }
 


### PR DESCRIPTION
logs based alerts doesnt re-trigger, it triggers a new instance
set these alerts to auto-close after an hour to avoid cluttering active alert list