### PR TITLE
Use `oip.Context()` in dispatcher to enable trace threading (later).

### DIFF
--- a/pkg/workqueue/dispatcher/dispatcher.go
+++ b/pkg/workqueue/dispatcher/dispatcher.go
@@ -99,7 +99,7 @@ func HandleAsync(ctx context.Context, wq workqueue.Interface, concurrency int, f
 			}
 
 			// Attempt to perform the actual reconciler invocation.
-			if err := f(ctx, oip.Name()); err != nil {
+			if err := f(oip.Context(), oip.Name()); err != nil {
 				clog.WarnContextf(ctx, "Failed callback for key %q: %v", oip.Name(), err)
 
 				// Requeue if it fails (stops heartbeat).


### PR DESCRIPTION
I realized this wasn't properly threaded when opening: https://github.com/chainguard-dev/terraform-infra-common/issues/554 spelling out how to save/restore trace headers.