### PR TITLE
`metrics.Handler` to return `http.HandlerFunc`

### DIFF
--- a/pkg/httpmetrics/metrics.go
+++ b/pkg/httpmetrics/metrics.go
@@ -96,7 +96,7 @@ func init() {
 }
 
 // Handler wraps a given http handler in standard metrics handlers.
-func Handler(name string, handler http.Handler) http.Handler {
+func Handler(name string, handler http.Handler) http.HandlerFunc {
 	verify := extractCloudRunCaller()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This allows the method to be used in places where a HandlerFunc (i.e. func(request, response)) is accepted without any casting.

Since `http.HandlerFunc` implements `http.Handler`, this should be backward compat.