### PR TITLE
feat(github-events): Record projects_v2_item events

### DIFF
--- a/modules/github-events/cmd/schemagen/main.go
+++ b/modules/github-events/cmd/schemagen/main.go
@@ -28,6 +28,7 @@ func main() {
 	mustGenerate("push.schema.json", schemas.Wrapper[schemas.PushEvent]{})
 	mustGenerate("check_run.schema.json", schemas.Wrapper[schemas.CheckRunEvent]{})
 	mustGenerate("check_suite.schema.json", schemas.Wrapper[schemas.CheckSuiteEvent]{})
+	mustGenerate("projects_v2_item.schema.json", schemas.Wrapper[schemas.ProjectsV2ItemEvent]{})
 }
 
 func mustGenerate[T any](path string, w schemas.Wrapper[T]) {

--- a/modules/github-events/main.tf
+++ b/modules/github-events/main.tf
@@ -117,5 +117,8 @@ output "recorder-schemas" {
     "dev.chainguard.github.check_suite" : {
       schema = file("${path.module}/schemas/check_suite.schema.json")
     }
+    "dev.chainguard.github.projects_v2_item" : {
+      schema = file("${path.module}/schemas/projects_v2_item.schema.json")
+    }
   }
 }

--- a/modules/github-events/schemas/event_types.go
+++ b/modules/github-events/schemas/event_types.go
@@ -271,3 +271,25 @@ type CheckSuiteEvent struct {
 	Organization Organization        `json:"organization,omitempty" bigquery:"organization"`
 	Sender       User                `json:"sender,omitempty" bigquery:"sender"`
 }
+
+// https://github.com/google/go-github/blob/v60.0.0/github/event_types.go#L1085
+type ProjectV2Item struct {
+	ID            bigquery.NullInt64     `json:"id,omitempty" bigquery:"id"`
+	NodeID        bigquery.NullString    `json:"node_id,omitempty" bigquery:"node_id"`
+	ProjectNodeID bigquery.NullString    `json:"project_node_id,omitempty" bigquery:"project_node_id"`
+	ContentNodeID bigquery.NullString    `json:"content_node_id,omitempty" bigquery:"content_node_id"`
+	ContentType   bigquery.NullString    `json:"content_type,omitempty" bigquery:"content_type"`
+	Creator       *User                  `json:"creator,omitempty" bigquery:"creator"`
+	CreatedAt     bigquery.NullTimestamp `json:"created_at,omitempty" bigquery:"created_at"`
+	UpdatedAt     bigquery.NullTimestamp `json:"updated_at,omitempty" bigquery:"updated_at"`
+	ArchivedAt    bigquery.NullTimestamp `json:"archived_at,omitempty" bigquery:"archived_at"`
+}
+
+// https://github.com/google/go-github/blob/v60.0.0/github/event_types.go#L1062
+type ProjectsV2ItemEvent struct {
+	Action        bigquery.NullString `json:"action,omitempty" bigquery:"action"`
+	Changes       bigquery.NullJSON   `json:"changes,omitempty" bigquery:"changes"`
+	ProjectV2Item *ProjectV2Item      `json:"projects_v2_item,omitempty" bigquery:"projects_v2_item"`
+	Organization  *Organization       `json:"organization,omitempty" bigquery:"organization"`
+	Sender        *User               `json:"sender,omitempty" bigquery:"sender"`
+}

--- a/modules/github-events/schemas/projects_v2_item.schema.json
+++ b/modules/github-events/schemas/projects_v2_item.schema.json
@@ -1,0 +1,96 @@
+[
+ {
+  "name": "when",
+  "type": "TIMESTAMP"
+ },
+ {
+  "fields": [
+   {
+    "name": "action",
+    "type": "STRING"
+   },
+   {
+    "name": "changes",
+    "type": "JSON"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "node_id",
+      "type": "STRING"
+     },
+     {
+      "name": "project_node_id",
+      "type": "STRING"
+     },
+     {
+      "name": "content_node_id",
+      "type": "STRING"
+     },
+     {
+      "name": "content_type",
+      "type": "STRING"
+     },
+     {
+      "fields": [
+       {
+        "name": "login",
+        "type": "STRING"
+       },
+       {
+        "name": "type",
+        "type": "STRING"
+       }
+      ],
+      "name": "creator",
+      "type": "RECORD"
+     },
+     {
+      "name": "created_at",
+      "type": "TIMESTAMP"
+     },
+     {
+      "name": "updated_at",
+      "type": "TIMESTAMP"
+     },
+     {
+      "name": "archived_at",
+      "type": "TIMESTAMP"
+     }
+    ],
+    "name": "projects_v2_item",
+    "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "login",
+      "type": "STRING"
+     }
+    ],
+    "name": "organization",
+    "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "login",
+      "type": "STRING"
+     },
+     {
+      "name": "type",
+      "type": "STRING"
+     }
+    ],
+    "name": "sender",
+    "type": "RECORD"
+   }
+  ],
+  "name": "body",
+  "type": "RECORD"
+ }
+]


### PR DESCRIPTION
This allows the capture of changes in field status from GitHub projects inside an organization.

The `changes` field can have many different forms. To capture everything, we save it as a JSON field to BigQuery. This change was tested in my dev environment.