### PR TITLE
add a secondary rate limit waiter to the github client

### DIFF
--- a/modules/github-bots/sdk/ratelimit.go
+++ b/modules/github-bots/sdk/ratelimit.go
@@ -1,0 +1,179 @@
+package sdk
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"golang.org/x/time/rate"
+)
+
+// SecondaryRateLimitWaiter
+type SecondaryRateLimitWaiter struct {
+	base              http.RoundTripper
+	limiter           *limiter
+	defaultRetryAfter time.Duration
+}
+
+func NewSecondaryRateLimitWaiterClient(base http.RoundTripper) *http.Client {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return &http.Client{
+		Transport: &SecondaryRateLimitWaiter{
+			base: base,
+			limiter: &limiter{
+				base: rate.NewLimiter(rate.Inf, 100),
+				mu:   sync.Mutex{},
+			},
+			defaultRetryAfter: 1 * time.Minute,
+		},
+	}
+}
+
+func (w *SecondaryRateLimitWaiter) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	if err := w.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	resp, err := w.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if w.processLimit(ctx, resp) {
+		return w.RoundTrip(req)
+	}
+
+	return resp, nil
+}
+
+// processLimit processes a response and returns a secondaryLimit if the response is a secondary limit
+// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+func (w *SecondaryRateLimitWaiter) processLimit(ctx context.Context, resp *http.Response) bool {
+	log := clog.FromContext(ctx)
+
+	if resp.StatusCode != http.StatusForbidden &&
+		resp.StatusCode != http.StatusTooManyRequests {
+		return false
+	}
+
+	var (
+		retryAfter time.Duration
+		reset      time.Time
+		remaining  int
+	)
+
+	// if "retry-after" is present, set the duration to wait before our retry
+	if v := resp.Header.Get(HeaderRetryAfter); v != "" {
+		seconds, err := strconv.Atoi(v)
+		if err != nil {
+			log.Warnf("failed to parse retry-after header: %v", err)
+		} else {
+			retryAfter = time.Duration(seconds) * time.Second
+		}
+	}
+
+	// if "x-ratelimit-remaining" is present, don't retry until after the time specified
+	if v := resp.Header.Get(HeaderXRateLimitRemaining); v != "" {
+		r, err := strconv.Atoi(v)
+		if err != nil {
+			log.Warnf("failed to parse x-ratelimit-remaining header: %v", err)
+		} else {
+			remaining = r
+		}
+	}
+
+	// if "x-ratelimit-reset" is present, don't retry until after the time specified
+	if v := resp.Header.Get(HeaderXRateLimitReset); v != "" {
+		seconds, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			log.Warnf("failed to parse x-ratelimit-reset header: %v", err)
+		} else {
+			reset = time.Unix(seconds, 0)
+		}
+	}
+
+	if retryAfter > 0 {
+		w.limiter.PauseFor(retryAfter)
+		return true
+	}
+
+	// If remaining is 0 and reset is not zero, wait until reset time
+	if remaining == 0 && !reset.IsZero() {
+		retryAfter = time.Until(reset)
+		w.limiter.PauseFor(retryAfter)
+		return true
+	}
+
+	// Default fallback if no rate-limit headers are present
+	w.limiter.PauseFor(w.defaultRetryAfter)
+	return true
+}
+
+// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+// NOTE: Use the go canonical form (capitals) for these headers, even though they are lowercase in the docs.
+const (
+	HeaderRetryAfter = "Retry-After"
+	// The time at which the current rate limit window resets, in UTC epoch seconds
+	HeaderXRateLimitReset = "X-Ratelimit-Reset"
+	// The number of requests remaining in the current rate limit window
+	HeaderXRateLimitRemaining = "X-Ratelimit-Remaining"
+)
+
+type limiter struct {
+	base       *rate.Limiter
+	mu         sync.Mutex
+	pauseUntil time.Time
+	pauseCh    chan struct{}
+}
+
+func (l *limiter) Wait(ctx context.Context) error {
+	l.mu.Lock()
+	pauseCh := l.pauseCh
+	l.mu.Unlock()
+
+	if pauseCh != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-pauseCh:
+		}
+	}
+
+	return l.base.Wait(ctx)
+}
+
+func (l *limiter) PauseFor(d time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	until := time.Now().Add(d)
+
+	if until.After(l.pauseUntil) {
+		l.pauseUntil = until
+		if l.pauseCh != nil {
+			close(l.pauseCh)
+		}
+		l.pauseCh = make(chan struct{})
+
+		go func(ch chan struct{}) {
+			timer := time.NewTimer(d)
+			defer timer.Stop()
+
+			<-timer.C
+			l.mu.Lock()
+			if ch == l.pauseCh {
+				close(ch)
+				l.pauseCh = nil
+				l.pauseUntil = time.Time{}
+			}
+			l.mu.Unlock()
+		}(l.pauseCh)
+	}
+}

--- a/modules/github-bots/sdk/ratelimit_test.go
+++ b/modules/github-bots/sdk/ratelimit_test.go
@@ -1,0 +1,183 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type testRT struct {
+	responses []*http.Response
+	mu        sync.Mutex
+	callCount int
+}
+
+func (t *testRT) RoundTrip(_ *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.callCount >= len(t.responses) {
+		return nil, fmt.Errorf("no more responses")
+	}
+	resp := t.responses[t.callCount]
+	t.callCount++
+	return resp, nil
+}
+
+func TestSecondaryRateLimitWaiter(t *testing.T) {
+	defaultRetryAfter := 1 * time.Second
+
+	tests := []struct {
+		name           string
+		responses      func(baseTime time.Time) []*http.Response
+		expectedCalls  int
+		expectedStatus int
+		expectedWait   time.Duration
+	}{
+		{
+			name: "No rate limit",
+			responses: func(_ time.Time) []*http.Response {
+				return []*http.Response{{StatusCode: http.StatusOK}}
+			},
+			expectedCalls:  1,
+			expectedWait:   0,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Rate limit with `x-ratelimit-reset`",
+			responses: func(baseTime time.Time) []*http.Response {
+				return []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Header: http.Header{
+							HeaderXRateLimitRemaining: []string{"0"},
+							HeaderXRateLimitReset:     []string{fmt.Sprintf("%d", baseTime.Add(4*time.Second).Unix())},
+						},
+					},
+					{StatusCode: http.StatusOK},
+				}
+			},
+			expectedCalls:  2,
+			expectedWait:   4 * time.Second,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Rate limit with `x-ratelimit-remaining`",
+			responses: func(baseTime time.Time) []*http.Response {
+				return []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Header: http.Header{
+							HeaderXRateLimitRemaining: []string{"0"},
+							HeaderXRateLimitReset:     []string{fmt.Sprintf("%d", baseTime.Add(4*time.Second).Unix())},
+						},
+					},
+					{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			expectedCalls:  2,
+			expectedWait:   4 * time.Second,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Rate limit with `retry-after`",
+			responses: func(_ time.Time) []*http.Response {
+				return []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Header: http.Header{
+							HeaderRetryAfter: {"2"},
+						},
+					},
+					{
+						StatusCode: http.StatusOK,
+					},
+				}
+			},
+			expectedCalls:  2,
+			expectedWait:   2 * time.Second,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Rate limited without headers uses the default retry-after",
+			responses: func(_ time.Time) []*http.Response {
+				return []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Header:     http.Header{},
+					},
+					{StatusCode: http.StatusOK},
+				}
+			},
+			expectedCalls:  2,
+			expectedWait:   defaultRetryAfter,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseTime := time.Now()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			trt := &testRT{
+				responses: tt.responses(baseTime),
+			}
+
+			client := &http.Client{
+				Transport: &SecondaryRateLimitWaiter{
+					base: trt,
+					limiter: &limiter{
+						base: rate.NewLimiter(rate.Inf, 100),
+						mu:   sync.Mutex{},
+					},
+					defaultRetryAfter: defaultRetryAfter,
+				},
+			}
+
+			req, err := http.NewRequest(http.MethodGet, "https://foobear.com", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			req = req.WithContext(ctx)
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("failed to make request: %v", err)
+			}
+			elapsed := time.Since(baseTime)
+
+			if resp != nil && resp.StatusCode != tt.expectedStatus {
+				t.Fatalf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+
+			if trt.callCount != tt.expectedCalls {
+				t.Fatalf("expected %d calls, got %d", tt.expectedCalls, trt.callCount)
+			}
+
+			// Apply some buffer to account for these bad tests and the fact that we're not mocking the clock
+			if tt.expectedWait == 0 {
+				if elapsed > 100*time.Millisecond {
+					t.Fatalf("expected no significant wait, but got %s", elapsed)
+				}
+			} else {
+				buffer := tt.expectedWait / 4 // 10% of expected wait
+				minExpectedWait := tt.expectedWait - buffer
+				maxExpectedWait := tt.expectedWait + buffer
+
+				if elapsed < minExpectedWait || elapsed > maxExpectedWait {
+					t.Fatalf("expected wait time between %s and %s, got %s", minExpectedWait, maxExpectedWait, elapsed)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
wrap the default client in a secondary rate limiter, the intent is for a transparent client side rate limiter tailored for GH's secondary rate limiter