### PR TITLE
Add a `NotBefore` option, use it for back-off during retries.

### DIFF
--- a/pkg/workqueue/gcs/gcs_test.go
+++ b/pkg/workqueue/gcs/gcs_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 
@@ -21,6 +22,9 @@ func TestWorkQueue(t *testing.T) {
 	if !ok {
 		t.Skip("WORKQUEUE_GCS_TEST_BUCKET not set")
 	}
+	// Adjust this to a suitable period for testing things.
+	// The conformance tests own adjusting MaximumBackoffPeriod.
+	workqueue.BackoffPeriod = 10 * time.Second
 
 	client, err := storage.NewClient(context.Background())
 	if err != nil {

--- a/pkg/workqueue/inmem/inmem_test.go
+++ b/pkg/workqueue/inmem/inmem_test.go
@@ -7,11 +7,17 @@ package inmem
 
 import (
 	"testing"
+	"time"
 
+	"github.com/chainguard-dev/terraform-infra-common/pkg/workqueue"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/workqueue/conformance"
 )
 
 func TestWorkQueue(t *testing.T) {
+	// Adjust this to a suitable period for testing things.
+	// The conformance tests own adjusting MaximumBackoffPeriod.
+	workqueue.BackoffPeriod = 1 * time.Second
+
 	conformance.TestSemantics(t, NewWorkQueue)
 
 	conformance.TestConcurrency(t, NewWorkQueue)

--- a/pkg/workqueue/interface.go
+++ b/pkg/workqueue/interface.go
@@ -7,6 +7,20 @@ package workqueue
 
 import (
 	"context"
+	"time"
+)
+
+// Note that these are variables, so that they can be modified by tests and
+// made flags in binary entrypoints.
+var (
+	// BackoffPeriod is the unit of backoff used when requeueing keys.
+	// This unit is combined with the number of attempts to determine the
+	// wait period before a key should be reprocessed.
+	BackoffPeriod = 30 * time.Second
+
+	// MaximumBackoffPeriod is a cap on the period a key must wait before
+	// being retried.
+	MaximumBackoffPeriod = 10 * time.Minute
 )
 
 // Interface is the interface that workqueue implementations must implement.
@@ -26,6 +40,10 @@ type Options struct {
 	// Priority is the priority of the key.
 	// Higher values are processed first.
 	Priority int64
+
+	// NotBefore is the earliest time that the key should be processed.
+	// When deduplicating, the oldest time is used.
+	NotBefore time.Time
 }
 
 // Key is a shared interface that all key types must implement.


### PR DESCRIPTION
This change adds a `NotBefore` option to the workqueue (not exposed via the proto yet), which directs the implementations to delay when certain keys appear in the queue for processing.

This same mechanism is now used to add a back-off when requeuing keys that carry a priority to keep failing high-priority tasks from starving low-priority tasks (h/t Nghia for thinking of this scenario).

```
WORKQUEUE_GCS_TEST_BUCKET=mattmoor-testing-workqueue go test -timeout=10m -count=1 ./pkg/workqueue/gcs
ok      github.com/chainguard-dev/terraform-infra-common/pkg/workqueue/gcs      262.813s
```