### PR TITLE
github-bots: optionally use a pre-defined service account email

### DIFF
--- a/modules/github-bots/README.md
+++ b/modules/github-bots/README.md
@@ -120,6 +120,7 @@ No requirements.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_raw_filter"></a> [raw\_filter](#input\_raw\_filter) | Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax | `string` | `""` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork. | <pre>map(object({<br/>    network = string<br/>    subnet  = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account being authorized to invoke the private Cloud Run service. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/github-bots/README.md
+++ b/modules/github-bots/README.md
@@ -120,7 +120,7 @@ No requirements.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_raw_filter"></a> [raw\_filter](#input\_raw\_filter) | Raw PubSub filter to apply, ignores other variables. https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax | `string` | `""` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | A map from region names to a network and subnetwork. | <pre>map(object({<br/>    network = string<br/>    subnet  = string<br/>  }))</pre> | n/a | yes |
-| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account being authorized to invoke the private Cloud Run service. | `string` | `""` | no |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account being authorized to invoke the private Cloud Run service. If empty, a service account will be created and used. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -1,4 +1,5 @@
 resource "google_service_account" "sa" {
+  count        = var.service_account_email == "" ? 1 : 0
   account_id   = "bot-${var.name}"
   display_name = "Service Account for ${var.name}"
 }
@@ -9,7 +10,9 @@ module "service" {
   name            = var.name
   project_id      = var.project_id
   regions         = var.regions
-  service_account = google_service_account.sa.email
+
+  service_account = var.service_account_email == "" ? google_service_account.sa[0].email : var.service_account_email
+
 
   egress = "PRIVATE_RANGES_ONLY" // Makes GitHub API calls
 

--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -4,6 +4,11 @@ resource "google_service_account" "sa" {
   display_name = "Service Account for ${var.name}"
 }
 
+moved {
+  from = google_service_account.sa
+  to = google_service_account.sa[0]
+}
+
 module "service" {
   source = "../regional-go-service"
 

--- a/modules/github-bots/outputs.tf
+++ b/modules/github-bots/outputs.tf
@@ -1,11 +1,11 @@
 output "serviceaccount-id" {
   description = "The ID of the service account for the bot."
-  value       = google_service_account.sa.unique_id
+  value       = var.service_account_email == "" ? google_service_account.sa[0].unique_id : ""
 }
 
 output "serviceaccount-email" {
   description = "The email of the service account for the bot."
-  value       = google_service_account.sa.email
+  value       = var.service_account_email == "" ? google_service_account.sa[0].email : var.service_account_email
 }
 
 

--- a/modules/github-bots/variables.tf
+++ b/modules/github-bots/variables.tf
@@ -125,7 +125,7 @@ variable "deletion_protection" {
 }
 
 variable "service_account_email" {
-  description = "The email of the service account being authorized to invoke the private Cloud Run service."
+  description = "The email of the service account being authorized to invoke the private Cloud Run service. If empty, a service account will be created and used."
   type        = string
   default     = ""
 }

--- a/modules/github-bots/variables.tf
+++ b/modules/github-bots/variables.tf
@@ -123,3 +123,9 @@ variable "deletion_protection" {
   description = "Whether to enable delete protection for the service."
   default     = true
 }
+
+variable "service_account_email" {
+  description = "The email of the service account being authorized to invoke the private Cloud Run service."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Allow passing a service account instead of always creating a service account.