### PR TITLE
fix: use local to precompute the condition

### DIFF
--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -1,5 +1,9 @@
+locals {
+  create_service_account = var.service_account_email == ""
+}
+
 resource "google_service_account" "sa" {
-  count        = var.service_account_email == "" ? 1 : 0
+  count        = local.create_service_account ? 1 : 0
   account_id   = "bot-${var.name}"
   display_name = "Service Account for ${var.name}"
 }


### PR DESCRIPTION
When using the new logic `serivce_account_email` in https://github.com/chainguard-dev/mono/actions/runs/11401132104/job/31886045677?pr=20472#step:15:131, I got the following error 😢:

```

Error: Invalid count argument

  on .terraform/modules/package-update-check.package-update-check/modules/github-bots/main.tf line 2, in resource "google_service_account" "sa":
   2:   count        = var.service_account_email == "" ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```