### PR TITLE
default launch stage now that vpc access is GA

### DIFF
--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -163,6 +163,12 @@ resource "google_cloud_run_v2_job" "job" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }
 
 data "google_client_config" "default" {}

--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -55,10 +55,6 @@ resource "google_cloud_run_v2_job" "job" {
   name     = "${var.name}-cron"
   location = var.region
 
-  # As Direct VPC is in BETA, we need to explicitly set the launch_stage to
-  # BETA in order to use it.
-  launch_stage = var.vpc_access != null ? "BETA" : null
-
   deletion_protection = var.deletion_protection
 
   template {

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -54,8 +54,6 @@ resource "google_cloud_run_v2_service" "this" {
   labels   = merge(var.labels, local.default_labels)
   ingress  = var.ingress
 
-  launch_stage = "BETA" // Needed for vpc_access below
-
   deletion_protection = var.deletion_protection
 
   template {

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -257,6 +257,12 @@ resource "google_cloud_run_v2_service" "this" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
 }
 
 // Get a project number for this project ID.


### PR DESCRIPTION
this is to reduce no-op diffs


example

```
  # module.build.module.handler["extras"].module.this.google_cloud_run_v2_service.this["us-central1"] will be updated in-place
  ~ resource "google_cloud_run_v2_service" "this" {
        id                      = "projects/staging-enforce-cd1e/locations/us-central1/services/build-extras"
      ~ launch_stage            = "GA" -> "BETA"
```


ignored example;
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job#example-usage---cloudrunv2-job-limits