### PR TITLE
change bad rollout to non-paging

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -42,7 +42,7 @@ resource "google_monitoring_alert_policy" "bad-rollout" {
     }
   }
 
-  notification_channels = length(var.notification_channels) != 0 ? var.notification_channels : local.oncall
+  notification_channels = length(var.notification_channels) != 0 ? var.notification_channels : local.slack
 
   enabled = "true"
   project = var.project_id


### PR DESCRIPTION
the idea is that the rollout is triggered by someone, and that person would be aware of it, so no need to further page.
this also supports individual stage/service rolling which may not be worthwhile to alert.

we may revisit this and have it page for critical services like api/issuer/datastore