### PR TITLE
rollforward Revert "disable rate squad alerts (#637)"

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -327,8 +327,6 @@ locals {
 }
 
 resource "google_monitoring_alert_policy" "service_failure_rate_non_eventing" {
-  count = var.squad == "" ? 1 : 0
-
   # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"
@@ -379,8 +377,6 @@ resource "google_monitoring_alert_policy" "service_failure_rate_non_eventing" {
 }
 
 resource "google_monitoring_alert_policy" "service_failure_rate_eventing" {
-  count = var.squad == "" ? 1 : 0
-
   # In the absence of data, incident will auto-close after an hour
   alert_strategy {
     auto_close = "3600s"


### PR DESCRIPTION
This reverts commit e6a192053e39cb60dcc6e25095542f0f9b2d9a72.

team label is now available on prometheus metrics.


for https://github.com/chainguard-dev/internal-dev/issues/4886
