### PR TITLE
github-bots: add a function to search for a filename in a repo

### DIFF
--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -579,6 +579,22 @@ func (c GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, ref
 	return content, nil
 }
 
+// SearchFilenameInRepository searches for a filename in a specific repository
+func (c GitHubClient) SearchFilenameInRepository(ctx context.Context, owner, repo, path string) (*github.CodeSearchResult, error) {
+	query := fmt.Sprintf("filename:%s repo:%s/%s", path, owner, repo)
+	result, resp, err := c.inner.Search.Code(
+		ctx,
+		query,
+		&github.SearchOptions{},
+	)
+
+	if err := validateResponse(ctx, err, resp, fmt.Sprintf("search filename %s in repository", path)); err != nil {
+		return &github.CodeSearchResult{}, err
+	}
+
+	return result, nil
+}
+
 // ListFiles lists the files in a directory at a given ref
 func (c GitHubClient) ListFiles(ctx context.Context, owner, repo, path, ref string) ([]*github.RepositoryContent, error) {
 	opts := &github.RepositoryContentGetOptions{Ref: ref}

--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -580,12 +580,17 @@ func (c GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, ref
 }
 
 // SearchFilenameInRepository searches for a filename in a specific repository
-func (c GitHubClient) SearchFilenameInRepository(ctx context.Context, owner, repo, path string) (*github.CodeSearchResult, error) {
+func (c GitHubClient) SearchFilenameInRepository(ctx context.Context, owner, repo, path string, opt *github.ListOptions) (*github.CodeSearchResult, error) {
+	if opt == nil {
+		opt = &github.ListOptions{}
+	}
 	query := fmt.Sprintf("filename:%s repo:%s/%s", path, owner, repo)
 	result, resp, err := c.inner.Search.Code(
 		ctx,
 		query,
-		&github.SearchOptions{},
+		&github.SearchOptions{
+			ListOptions: *opt,
+		},
 	)
 
 	if err := validateResponse(ctx, err, resp, fmt.Sprintf("search filename %s in repository", path)); err != nil {

--- a/modules/github-bots/sdk/github_integration_test.go
+++ b/modules/github-bots/sdk/github_integration_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+// +build integration
+
+package sdk
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-github/v61/github"
+)
+
+// NOTE: This is an integration test that requires 'GITHUB_TOKEN' env variable to be set!
+// It is recommended to run this test in a local environment.
+func Test_SearchFilenameInRepository(t *testing.T) {
+	ctx := context.Background()
+
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Fatalf("GITHUB_TOKEN env var not set\n")
+	}
+
+	// create a GitHub client
+	repoOrg := "kserve"
+	repoName := "kserve"
+	// sdk allows an override of GIT_TOKEN env var so we can test from a local environment
+	cli := NewGitHubClient(ctx, repoOrg, repoName, "test")
+	result, err := cli.SearchFilenameInRepository(ctx, repoOrg, repoName, "pyproject.toml", &github.ListOptions{})
+	if err != nil {
+		t.Fatalf("SearchFilenameInRepository err: %v\n", err)
+	}
+
+	if *result.Total == 0 {
+		t.Fatalf("SearchFilenameInRepository result is zero\n")
+	}
+}

--- a/modules/github-bots/test/main.go
+++ b/modules/github-bots/test/main.go
@@ -1,0 +1,1 @@
+package test

--- a/modules/github-bots/test/main.go
+++ b/modules/github-bots/test/main.go
@@ -1,1 +1,0 @@
-package test


### PR DESCRIPTION
On the ai remediation bot, we need to search for specific filenames on a repository such as go.mod, pyproject.toml, Cargo.toml... If these files are found then we get the content specifying the path using another existing function GetFileContent which would be used to generate a precise patch.