### PR TITLE
github-events: Add installation, hook ID, and headers to event messages.

### DIFF
--- a/modules/github-events/schemas/check_run.schema.json
+++ b/modules/github-events/schemas/check_run.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/check_run.schema.json
+++ b/modules/github-events/schemas/check_run.schema.json
@@ -568,6 +568,20 @@
     ],
     "name": "sender",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/check_suite.schema.json
+++ b/modules/github-events/schemas/check_suite.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/check_suite.schema.json
+++ b/modules/github-events/schemas/check_suite.schema.json
@@ -330,6 +330,20 @@
     ],
     "name": "sender",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/event_types.go
+++ b/modules/github-events/schemas/event_types.go
@@ -7,8 +7,18 @@ import (
 )
 
 type Wrapper[T any] struct {
-	When time.Time
-	Body T
+	When    time.Time
+	Headers *GitHubHeaders
+	Body    T
+}
+
+type GitHubHeaders struct {
+	HookID                 bigquery.NullString `json:"hook_id,omitempty" bigquery:"hook_id"`
+	DeliveryID             bigquery.NullString `json:"delivery_id,omitempty" bigquery:"delivery_id"`
+	UserAgent              bigquery.NullString `json:"user_agent,omitempty" bigquery:"user_agent"`
+	Event                  bigquery.NullString `json:"event,omitempty" bigquery:"event"`
+	InstallationTargetType bigquery.NullString `json:"installation_target_type,omitempty" bigquery:"installation_target_type"`
+	InstallationTargetID   bigquery.NullString `json:"installation_target_id,omitempty" bigquery:"installation_target_id"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#User

--- a/modules/github-events/schemas/event_types.go
+++ b/modules/github-events/schemas/event_types.go
@@ -30,6 +30,14 @@ type Repository struct {
 	FullName bigquery.NullString `json:"full_name,omitempty" bigquery:"full_name"`
 }
 
+// https://pkg.go.dev/github.com/google/go-github/v60/github#Installation
+type Installation struct {
+	// Installation ID
+	ID bigquery.NullInt64 `json:"id,omitempty" bigquery:"id"`
+	// App ID
+	AppID bigquery.NullInt64 `json:"app_id,omitempty" bigquery:"app_id"`
+}
+
 // https://pkg.go.dev/github.com/google/go-github/v60/github#PullRequestBranch
 type PullRequestBranch struct {
 	Ref  bigquery.NullString `json:"ref,omitempty" bigquery:"ref"`
@@ -91,6 +99,8 @@ type PullRequestEvent struct {
 	// Populated when action is synchronize
 	Before bigquery.NullString `json:"before,omitempty" bigquery:"before"`
 	After  bigquery.NullString `json:"after,omitempty" bigquery:"after"`
+
+	Installation *Installation `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v61/github#PushEventRepository
@@ -119,6 +129,8 @@ type PushEvent struct {
 	Sender  User                `json:"sender,omitempty" bigquery:"sender"`
 
 	Organization Organization `json:"organization,omitempty" bigquery:"organization"`
+
+	Installation *Installation `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#Workflow
@@ -158,6 +170,7 @@ type WorkflowRunEvent struct {
 	Organization Organization        `json:"organization,omitempty" bigquery:"organization"`
 	Repository   Repository          `json:"repository,omitempty" bigquery:"repository"`
 	Sender       User                `json:"sender,omitempty" bigquery:"sender"`
+	Installation *Installation       `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#IssueCommentEvent
@@ -168,6 +181,7 @@ type IssueCommentEvent struct {
 	Repo         Repository          `json:"repository,omitempty" bigquery:"repository"`
 	Sender       User                `json:"sender,omitempty" bigquery:"sender"`
 	Organization Organization        `json:"organization,omitempty" bigquery:"organization"`
+	Installation *Installation       `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#IssueEvent
@@ -187,6 +201,7 @@ type IssueEvent struct {
 	LockReason        bigquery.NullString    `json:"lock_reason,omitempty" bigquery:"lock_reason"`
 	RequestedReviewer User                   `json:"requested_reviewer,omitempty" bigquery:"requested_reviewer"`
 	ReviewRequester   User                   `json:"review_requester,omitempty" bigquery:"review_requester"`
+	Installation      *Installation          `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#Issue
@@ -236,6 +251,7 @@ type CheckRunEvent struct {
 	Repository   Repository          `json:"repository,omitempty" bigquery:"repository"`
 	Organization Organization        `json:"organization,omitempty" bigquery:"organization"`
 	Sender       User                `json:"sender,omitempty" bigquery:"sender"`
+	Installation *Installation       `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://pkg.go.dev/github.com/google/go-github/v60/github#CheckRun
@@ -270,6 +286,7 @@ type CheckSuiteEvent struct {
 	Repository   Repository          `json:"repository,omitempty" bigquery:"repository"`
 	Organization Organization        `json:"organization,omitempty" bigquery:"organization"`
 	Sender       User                `json:"sender,omitempty" bigquery:"sender"`
+	Installation *Installation       `json:"installation,omitempty" bigquery:"installation"`
 }
 
 // https://github.com/google/go-github/blob/v60.0.0/github/event_types.go#L1085
@@ -292,4 +309,5 @@ type ProjectsV2ItemEvent struct {
 	ProjectV2Item *ProjectV2Item      `json:"projects_v2_item,omitempty" bigquery:"projects_v2_item"`
 	Organization  *Organization       `json:"organization,omitempty" bigquery:"organization"`
 	Sender        *User               `json:"sender,omitempty" bigquery:"sender"`
+	Installation  *Installation       `json:"installation,omitempty" bigquery:"installation"`
 }

--- a/modules/github-events/schemas/issue_comment.schema.json
+++ b/modules/github-events/schemas/issue_comment.schema.json
@@ -302,6 +302,20 @@
     ],
     "name": "organization",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/issue_comment.schema.json
+++ b/modules/github-events/schemas/issue_comment.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/issues.schema.json
+++ b/modules/github-events/schemas/issues.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "id",
     "type": "INTEGER"
    },

--- a/modules/github-events/schemas/issues.schema.json
+++ b/modules/github-events/schemas/issues.schema.json
@@ -356,6 +356,20 @@
     ],
     "name": "review_requester",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/projects_v2_item.schema.json
+++ b/modules/github-events/schemas/projects_v2_item.schema.json
@@ -88,6 +88,20 @@
     ],
     "name": "sender",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/projects_v2_item.schema.json
+++ b/modules/github-events/schemas/projects_v2_item.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/pull_request.schema.json
+++ b/modules/github-events/schemas/pull_request.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/pull_request.schema.json
+++ b/modules/github-events/schemas/pull_request.schema.json
@@ -289,6 +289,20 @@
    {
     "name": "after",
     "type": "STRING"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/push.schema.json
+++ b/modules/github-events/schemas/push.schema.json
@@ -96,6 +96,20 @@
     ],
     "name": "organization",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",

--- a/modules/github-events/schemas/push.schema.json
+++ b/modules/github-events/schemas/push.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "push_id",
     "type": "INTEGER"
    },

--- a/modules/github-events/schemas/workflow_run.schema.json
+++ b/modules/github-events/schemas/workflow_run.schema.json
@@ -6,6 +6,36 @@
  {
   "fields": [
    {
+    "name": "hook_id",
+    "type": "STRING"
+   },
+   {
+    "name": "delivery_id",
+    "type": "STRING"
+   },
+   {
+    "name": "user_agent",
+    "type": "STRING"
+   },
+   {
+    "name": "event",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_type",
+    "type": "STRING"
+   },
+   {
+    "name": "installation_target_id",
+    "type": "STRING"
+   }
+  ],
+  "name": "headers",
+  "type": "RECORD"
+ },
+ {
+  "fields": [
+   {
     "name": "action",
     "type": "STRING"
    },

--- a/modules/github-events/schemas/workflow_run.schema.json
+++ b/modules/github-events/schemas/workflow_run.schema.json
@@ -140,6 +140,20 @@
     ],
     "name": "sender",
     "type": "RECORD"
+   },
+   {
+    "fields": [
+     {
+      "name": "id",
+      "type": "INTEGER"
+     },
+     {
+      "name": "app_id",
+      "type": "INTEGER"
+     }
+    ],
+    "name": "installation",
+    "type": "RECORD"
    }
   ],
   "name": "body",


### PR DESCRIPTION
- Adds installation message for identifying GitHub App installations. These won't be present in the legacy repo based webhooks.
- Adds X-GitHub-Hook-ID as an extension to make it filterable by downstream clients.
- Records the incoming event headers in the body payload, which includes useful info for debugging (e.g. delivery IDs).

Part of https://github.com/chainguard-dev/internal-dev/issues/1513