### PR TITLE
check sdk: return {Create,Update}CheckRunOptions

### DIFF
--- a/modules/github-bots/sdk/check/check.go
+++ b/modules/github-bots/sdk/check/check.go
@@ -64,13 +64,13 @@ func (b *Builder) Writef(format string, args ...any) {
 //
 // If the Summary field is empty, it will be set to the name field.
 // If the Conclusion field is set, the CheckRun will be marked as completed.
-func (b *Builder) CheckRun() *github.CheckRun {
+func (b *Builder) CheckRunCreate() *github.CreateCheckRunOptions {
 	if b.Summary == "" {
 		b.Summary = b.name
 	}
-	cr := &github.CheckRun{
-		Name:    &b.name,
-		HeadSHA: &b.headSHA,
+	cr := &github.CreateCheckRunOptions{
+		Name:    b.name,
+		HeadSHA: b.headSHA,
 		Output: &github.CheckRunOutput{
 			Title:   &b.Summary,
 			Summary: &b.Summary,
@@ -90,4 +90,18 @@ func (b *Builder) CheckRun() *github.CheckRun {
 		cr.Status = github.String("completed")
 	}
 	return cr
+}
+
+func (b *Builder) CheckRunUpdate() *github.UpdateCheckRunOptions {
+	create := b.CheckRunCreate()
+	return &github.UpdateCheckRunOptions{
+		Name:       create.Name,
+		Status:     create.Status,
+		Conclusion: create.Conclusion,
+		Output: &github.CheckRunOutput{
+			Title:   create.GetOutput().Title,
+			Summary: create.GetOutput().Summary,
+			Text:    create.GetOutput().Text,
+		},
+	}
 }

--- a/modules/github-bots/sdk/check/check_test.go
+++ b/modules/github-bots/sdk/check/check_test.go
@@ -12,24 +12,34 @@ func TestCheckRun(t *testing.T) {
 	b := NewBuilder("name", "headSHA")
 	b.Writef("test %d", 123)
 
-	if diff := cmp.Diff(b.CheckRun(), &github.CheckRun{
-		Name:    github.String("name"),
-		HeadSHA: github.String("headSHA"),
+	if diff := cmp.Diff(b.CheckRunCreate(), &github.CreateCheckRunOptions{
+		Name:    "name",
+		HeadSHA: "headSHA",
 		Output: &github.CheckRunOutput{
 			Title:   github.String("name"),
 			Summary: github.String("name"),
 			Text:    github.String("test 123\n"),
 		},
 	}); diff != "" {
-		t.Errorf("CheckRun() mismatch (-want +got):\n%s", diff)
+		t.Errorf("CheckRunCreate() mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(b.CheckRunUpdate(), &github.UpdateCheckRunOptions{
+		Name: "name",
+		Output: &github.CheckRunOutput{
+			Title:   github.String("name"),
+			Summary: github.String("name"),
+			Text:    github.String("test 123\n"),
+		},
+	}); diff != "" {
+		t.Errorf("CheckRunUpdate() mismatch (-want +got):\n%s", diff)
 	}
 
 	b.Summary = "summary"
 	b.Conclusion = ConclusionSuccess
 	b.Writef("test %t", true)
-	if diff := cmp.Diff(b.CheckRun(), &github.CheckRun{
-		Name:       github.String("name"),
-		HeadSHA:    github.String("headSHA"),
+	if diff := cmp.Diff(b.CheckRunCreate(), &github.CreateCheckRunOptions{
+		Name:       "name",
+		HeadSHA:    "headSHA",
 		Status:     github.String("completed"),
 		Conclusion: github.String("success"),
 		Output: &github.CheckRunOutput{
@@ -38,8 +48,21 @@ func TestCheckRun(t *testing.T) {
 			Text:    github.String("test 123\ntest true\n"),
 		},
 	}); diff != "" {
-		t.Errorf("CheckRun() mismatch (-want +got):\n%s", diff)
+		t.Errorf("CheckRunCreate() mismatch (-want +got):\n%s", diff)
 	}
+	if diff := cmp.Diff(b.CheckRunUpdate(), &github.UpdateCheckRunOptions{
+		Name:       "name",
+		Status:     github.String("completed"),
+		Conclusion: github.String("success"),
+		Output: &github.CheckRunOutput{
+			Title:   github.String("summary"),
+			Summary: github.String("summary"),
+			Text:    github.String("test 123\ntest true\n"),
+		},
+	}); diff != "" {
+		t.Errorf("CheckRunCreate() mismatch (-want +got):\n%s", diff)
+	}
+
 }
 
 func TestWritef(t *testing.T) {
@@ -55,13 +78,13 @@ func TestWritef(t *testing.T) {
 		}
 	}
 
-	gotText := b.CheckRun().GetOutput().GetText()
+	gotText := b.CheckRunCreate().GetOutput().GetText()
 	wantLength := maxCheckOutputLength
 	if len(gotText) != wantLength {
-		t.Fatalf("CheckRun().Output.Text length = %d, want %d", len(gotText), wantLength)
+		t.Fatalf("CheckRunCreate().Output.Text length = %d, want %d", len(gotText), wantLength)
 	}
 	if !strings.HasSuffix(gotText, truncationMessage) {
 		last100 := gotText[len(gotText)-100:]
-		t.Errorf("CheckRun().Output.Text does not have truncation message, ends with %q", last100)
+		t.Errorf("CheckRunCreate().Output.Text does not have truncation message, ends with %q", last100)
 	}
 }

--- a/modules/github-bots/sdk/check/check_test.go
+++ b/modules/github-bots/sdk/check/check_test.go
@@ -62,7 +62,6 @@ func TestCheckRun(t *testing.T) {
 	}); diff != "" {
 		t.Errorf("CheckRunCreate() mismatch (-want +got):\n%s", diff)
 	}
-
 }
 
 func TestWritef(t *testing.T) {


### PR DESCRIPTION
Callers don't tend to work in `CheckRun`s themselves, but rather `CreateCheckRunOptions`es (to create runs) or `UpdateCheckRunOptions`es (to update them).

There's no built-in method to convert a `CheckRun` into either of those, so we'll just do it ourselves.

To avoid duplication, `UpdateCheckRun()` just calls `CreateCheckRun()` and twiddles its values.