### PR TITLE
Check SDK: support in_progress checks

### DIFF
--- a/modules/github-bots/sdk/check/check.go
+++ b/modules/github-bots/sdk/check/check.go
@@ -14,6 +14,17 @@ const (
 	truncationMessage    = "\n\n⚠️ _Summary has been truncated_"
 )
 
+type Status string
+
+const (
+	StatusQueued     Status = "queued"
+	StatusInProgress Status = "in_progress"
+	StatusCompleted  Status = "completed"
+	StatusWaiting    Status = "waiting"
+	StatusRequested  Status = "requested"
+	StatusPending    Status = "pending"
+)
+
 type Conclusion string
 
 const (
@@ -32,6 +43,7 @@ type Builder struct {
 	md            strings.Builder
 	name, headSHA string
 	Summary       string
+	Status        Status
 	Conclusion    Conclusion
 }
 
@@ -71,6 +83,7 @@ func (b *Builder) CheckRunCreate() *github.CreateCheckRunOptions {
 	cr := &github.CreateCheckRunOptions{
 		Name:    b.name,
 		HeadSHA: b.headSHA,
+		Status:  github.String(string(StatusInProgress)),
 		Output: &github.CheckRunOutput{
 			Title:   &b.Summary,
 			Summary: &b.Summary,
@@ -87,7 +100,7 @@ func (b *Builder) CheckRunCreate() *github.CreateCheckRunOptions {
 	// Providing conclusion will automatically set the status parameter to completed.
 	if b.Conclusion != "" {
 		cr.Conclusion = github.String(string(b.Conclusion))
-		cr.Status = github.String("completed")
+		cr.Status = github.String(string(StatusCompleted))
 	}
 	return cr
 }

--- a/modules/github-bots/sdk/check/check_test.go
+++ b/modules/github-bots/sdk/check/check_test.go
@@ -10,11 +10,13 @@ import (
 
 func TestCheckRun(t *testing.T) {
 	b := NewBuilder("name", "headSHA")
+	b.Status = StatusInProgress
 	b.Writef("test %d", 123)
 
 	if diff := cmp.Diff(b.CheckRunCreate(), &github.CreateCheckRunOptions{
 		Name:    "name",
 		HeadSHA: "headSHA",
+		Status:  github.String("in_progress"),
 		Output: &github.CheckRunOutput{
 			Title:   github.String("name"),
 			Summary: github.String("name"),
@@ -24,7 +26,8 @@ func TestCheckRun(t *testing.T) {
 		t.Errorf("CheckRunCreate() mismatch (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(b.CheckRunUpdate(), &github.UpdateCheckRunOptions{
-		Name: "name",
+		Name:   "name",
+		Status: github.String("in_progress"),
 		Output: &github.CheckRunOutput{
 			Title:   github.String("name"),
 			Summary: github.String("name"),


### PR DESCRIPTION
Prior to this the default status was `queued`, which is misleading if a check wants to say it's started and then later finished.