### PR TITLE
github sdk: CloneRepo forces checkout

### DIFF
--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -536,6 +536,7 @@ func (c GitHubClient) CloneRepo(ctx context.Context, ref, destDir string) (*git.
 	}
 	if err := wt.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.ReferenceName(ref),
+		Force:  true, // There should not be any local changes, but just in case.
 	}); err != nil {
 		return nil, fmt.Errorf("failed to checkout ref %s: %w", ref, err)
 	}


### PR DESCRIPTION
If there are dangling symlinks in the repo, checkout fails with `worktree contains unstaged changes` -- since we're cloning here, there should be no local changes to lose, and we should force the checkout.