### PR TITLE
add GH required attribute_condition

### DIFF
--- a/modules/github-wif-provider/README.md
+++ b/modules/github-wif-provider/README.md
@@ -31,6 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_github_org"></a> [github\_org](#input\_github\_org) | The GitHub organizantion to grant access to. Eg: 'chainguard-dev'. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the provider pool. | `string` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | The list of notification channels to alert when this policy fires. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -43,4 +43,6 @@ resource "google_iam_workload_identity_pool_provider" "this" {
     "attribute.versiontags"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.versiontagsanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false')"
   }
+
+  attribute_condition = "assertion.repository_owner == '${var.github_org}'"
 }

--- a/modules/github-wif-provider/variables.tf
+++ b/modules/github-wif-provider/variables.tf
@@ -11,3 +11,8 @@ variable "notification_channels" {
   description = "The list of notification channels to alert when this policy fires."
   type        = list(string)
 }
+
+variable "github_org" {
+  description = "The GitHub organizantion to grant access to. Eg: 'chainguard-dev'."
+  type        = string
+}


### PR DESCRIPTION
this module hasn't been updated in a while, and it seems to have fallen into a broken state.

```
╷
│ Error: Error creating WorkloadIdentityPoolProvider: googleapi: Error 400: The attribute condition must reference one of the provider's claims. For more information, see https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#conditions
│
│   with module.github_wif.google_iam_workload_identity_pool_provider.this,
│   on .terraform/modules/github_wif/modules/github-wif-provider/main.tf line 8, in resource "google_iam_workload_identity_pool_provider" "this":
│    8: resource "google_iam_workload_identity_pool_provider" "this" {
```

according to https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#conditions, for GH WIF, the following `attribute_condition` is now required:

> Warning: GitHub, GitLab SaaS, and Terraform Cloud use a single issuer URL across all organizations and some of the claims embedded in OIDC tokens might not be unique to your organization. To help protect against [spoofing threats](https://cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation#protecting_against_spoofing_threats), you must use an attribute condition that restricts access to tokens issued by your GitHub organization, GitLab group, or Terraform Cloud organization.

this PR adds `var.repository_owner` as a required variable (a breaking change), but I think this is ok since the module is already broken, now it'll at least fail with a reason/fix
