### PR TITLE
github-events: Use organization field for org filter.

### DIFF
--- a/modules/github-events/internal/trampoline/server.go
+++ b/modules/github-events/internal/trampoline/server.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/chainguard-dev/clog"
@@ -105,6 +104,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Repository struct {
 			FullName string `json:"full_name"`
 		} `json:"repository"`
+		Organization struct {
+			Login string `json:"login"`
+		} `json:"organization"`
 	}
 	if err := json.Unmarshal(payload, &msg); err != nil {
 		log.Warnf("failed to unmarshal payload; action and subject will be unset: %v", err)
@@ -116,7 +118,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if len(s.orgFilter) > 0 {
 		found := false
 		for _, org := range s.orgFilter {
-			if strings.HasPrefix(msg.Repository.FullName, org+"/") {
+			if msg.Organization.Login == org {
 				found = true
 				break
 			}

--- a/modules/github-events/internal/trampoline/server_test.go
+++ b/modules/github-events/internal/trampoline/server_test.go
@@ -177,6 +177,9 @@ func TestRequestedOnlyWebhook(t *testing.T) {
 		"repository": map[string]interface{}{
 			"full_name": "org/repo",
 		},
+		"organization": map[string]interface{}{
+			"login": "org",
+		},
 	}, secret)
 	if err != nil {
 		t.Fatalf("error sending event: %v", err)
@@ -219,6 +222,9 @@ func TestOrgFilter(t *testing.T) {
 		"action": "opened",
 		"repository": map[string]interface{}{
 			"full_name": "org/repo",
+		},
+		"organization": map[string]interface{}{
+			"login": "org",
 		},
 	}, secret)
 	if err != nil {


### PR DESCRIPTION
Some events (`projects_v2_item`) don't have an associated repo, so it's not present in the message. They all should have the organization field (spot checked this on `projects_v2_item` and `check_run.completed`).