### PR TITLE
refactor node pool network configs to use dynamic and pass `enable_private_nodes` as var

### DIFF
--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -126,3 +126,9 @@ variable "deletion_protection" {
   default     = true
   description = "Toggle to prevent accidental deletion of resources."
 }
+
+variable "enable_private_nodes" {
+  type        = bool
+  default     = false
+  description = "Enable private nodes by default"
+}


### PR DESCRIPTION
Even though the [documentation for `google_node_pool.network_config` states you can use a blank value for `pod_ipv4_cidr_block`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#nested_network_config), this throws an error on `terraform plan/apply`. It also appears to be a known issue. Instead, only set the block if values are passed, otherwise `null` reverts to defaults. 

Also pass `enable_private_nodes` for cluster config as a variable.