### PR TITLE
cron: don't parse base_image when importpath=""

### DIFF
--- a/modules/cron/README.md
+++ b/modules/cron/README.md
@@ -104,7 +104,7 @@ No modules.
 | <a name="input_env"></a> [env](#input\_env) | A map of custom environment variables (e.g. key=value) | `map` | `{}` | no |
 | <a name="input_exec"></a> [exec](#input\_exec) | Whether to execute job on modify. | `bool` | `false` | no |
 | <a name="input_execution_environment"></a> [execution\_environment](#input\_execution\_environment) | The execution environment to use for the job. | `string` | `""` | no |
-| <a name="input_importpath"></a> [importpath](#input\_importpath) | The import path that contains the cron application. Leave empty to run the unmodified base image as the application: for example, when running an `apko`-built image. This works by skipping the `ko` build and just use the base image directly in the cron job. | `string` | `""` | no |
+| <a name="input_importpath"></a> [importpath](#input\_importpath) | The import path that contains the cron application. Leave empty to run the unmodified base image as the application: for example, when running an `apko`-built image. This works by skipping the `ko` build and just use the base image directly in the cron job. A digest must be specified in this case. | `string` | `""` | no |
 | <a name="input_invokers"></a> [invokers](#input\_invokers) | List of iam members invoker perimssions to invoke the job. | `list(string)` | `[]` | no |
 | <a name="input_ko_build_env"></a> [ko\_build\_env](#input\_ko\_build\_env) | A list of custom environment variables to pass to the ko build. | `list(string)` | `[]` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the job. | `map(string)` | `{}` | no |

--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -36,7 +36,7 @@ resource "ko_build" "image" {
 }
 
 locals {
-  parsed = provider::oci::parse(var.base_image)
+  parsed = var.importpath == "" ? provider::oci::parse(var.base_image) : {}
   ref    = var.importpath == "" ? "${local.parsed.registry_repo}@${local.parsed.digest}" : ko_build.image[0].image_ref
 }
 

--- a/modules/cron/variables.tf
+++ b/modules/cron/variables.tf
@@ -35,7 +35,7 @@ variable "service_account" {
 
 variable "importpath" {
   type        = string
-  description = "The import path that contains the cron application. Leave empty to run the unmodified base image as the application: for example, when running an `apko`-built image. This works by skipping the `ko` build and just use the base image directly in the cron job."
+  description = "The import path that contains the cron application. Leave empty to run the unmodified base image as the application: for example, when running an `apko`-built image. This works by skipping the `ko` build and just use the base image directly in the cron job. A digest must be specified in this case."
   default     = ""
 }
 


### PR DESCRIPTION
Because `oci::parse` only accepts digests, don't call it when `importpath=""` for backward compatibility. I will follow up with another fix to also accept tags for when `importpath=""`, but for now this should fix the broken backward compatibility introduced in #734 