### PR TITLE
fix escaping for label extractor for exit code alert policy

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -406,7 +406,7 @@ resource "google_monitoring_alert_policy" "nonzero-exitcode" {
         "job_name"      = "EXTRACT(resource.labels.job_name)"
         "location"      = "EXTRACT(resource.labels.location)"
         "team"          = "EXTRACT(protoPayload.response.metadata.labels.squad)"
-        "exit_code"     = "REGEXP_EXTRACT(textPayload, \"^Container called exit\\(([0-9]+)\\)\\.$\")"
+        "exit_code"     = "REGEXP_EXTRACT(textPayload, \"^Container called exit\\\\(([0-9]+)\\\\)\\\\.$\")"
       }
     }
   }


### PR DESCRIPTION
need \\\\ for \ for re2

first is to escape terraform
second is to escape string field in api

\\\\ => \\ => \