### PR TITLE
feat(sdk): new GitAuth method on GitHubClient

### DIFF
--- a/modules/github-bots/sdk/github.go
+++ b/modules/github-bots/sdk/github.go
@@ -209,6 +209,16 @@ func (c GitHubClient) GitAuth() (transport.AuthMethod, error) {
 	return auth, nil
 }
 
+// RepoURL returns the HTTPS git URL of the GitHubClient's configured
+// repository.
+func (c GitHubClient) RepoURL() (string, error) {
+	if c.org == "" || c.repo == "" {
+		return "", errors.New("GitHubClient is not configured with both an org and repo")
+	}
+
+	return fmt.Sprintf("https://github.com/%s/%s.git", c.org, c.repo), nil
+}
+
 // checkRateLimiting checks for github API rate limiting. It attempts to use
 // the returned Retry-After header to calculate the delay returned from the API.
 //
@@ -575,7 +585,10 @@ func (c GitHubClient) CloneRepo(ctx context.Context, ref, destDir string) (*git.
 		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	repo := fmt.Sprintf("https://github.com/%s/%s.git", c.org, c.repo)
+	repo, err := c.RepoURL()
+	if err != nil {
+		return nil, fmt.Errorf("getting repository URL: %w", err)
+	}
 	auth, err := c.GitAuth()
 	if err != nil {
 		return nil, fmt.Errorf("retrieving GitHub client's auth: %w", err)


### PR DESCRIPTION
I found myself wanting to use the `go-git` library in the same context as using this `GitHubClient`.

The `GitHubClient` seems awesome as a centralized, elegant way to handle OctoSTS auth, that automatically does all the right things.

But then I wanted to do more git things to the repo. For example, I wanted to clone a repo, but I didn't want to do all of the specific maneuvers that the `GitHubClient`'s existing `CloneRepo` method does. I wanted the power of the raw `go-git` library, but I didn't want to have to reinvent an auth solution when I do that.

Let me know if there's a better solution to this problem!