### PR TITLE
Add `project_id` in googlemanagedprometheus config

### DIFF
--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -164,7 +164,8 @@ resource "google_cloud_run_v2_job" "job" {
           args = ["--config=env:OTEL_CONFIG"]
           env {
             name  = "OTEL_CONFIG"
-            value = file("${path.module}/otel-config/config.yaml")
+            value = replace(file("${path.module}/otel-config/config.yaml"),
+              "REPLACE_ME_PROJECT_ID", var.project_id)
           }
         }
       }

--- a/modules/cron/otel-config/config.yaml
+++ b/modules/cron/otel-config/config.yaml
@@ -56,6 +56,7 @@ processors:
 
 exporters:
   googlemanagedprometheus:
+    project: "REPLACE_ME_PROJECT_ID"
     sending_queue:
       enabled: true
       # we are handling metrics for a single pod, no need to have

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -264,8 +264,10 @@ resource "google_cloud_run_v2_service" "this" {
       // config via env is an option; https://pkg.go.dev/go.opentelemetry.io/collector/service#section-readme
       args = ["--config=env:OTEL_CONFIG"]
       env {
-        name  = "OTEL_CONFIG"
-        value = replace(file("${path.module}/otel-config/config.yaml"), "REPLACE_ME_TEAM", var.squad)
+        name = "OTEL_CONFIG"
+        value = replace(replace(file("${path.module}/otel-config/config.yaml"),
+          "REPLACE_ME_TEAM", var.squad),
+        "REPLACE_ME_PROJECT_ID", var.project_id)
       }
     }
 

--- a/modules/regional-service/otel-config/config.yaml
+++ b/modules/regional-service/otel-config/config.yaml
@@ -62,6 +62,7 @@ processors:
 
 exporters:
   googlemanagedprometheus:
+    project: "REPLACE_ME_PROJECT_ID"
     sending_queue:
       enabled: true
       # we are handling metrics for a single pod, no need to have


### PR DESCRIPTION
To avoid the plugin crashing when metadata server has not come up yet.