### PR TITLE
alerting: Add exitcode filter

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -371,6 +371,7 @@ textPayload:"Container called exit("
 -textPayload="Container called exit(0)."
 -textPayload=~"Container called exit\(1[3-4]\d\)."
 ${local.squad_log_filter}
+${var.exitcode_filter}
 EOF
 }
 

--- a/modules/alerting/variables.tf
+++ b/modules/alerting/variables.tf
@@ -56,6 +56,12 @@ variable "scaling_issue_filter" {
   default     = ""
 }
 
+variable "exitcode_filter" {
+  description = "additional filter to apply to exitcode alert policy"
+  type        = string
+  default     = ""
+}
+
 variable "failure_rate_ratio_threshold" {
   description = "ratio threshold to alert for cloud run server failure rate."
   type        = number


### PR DESCRIPTION
Adds a new filter variable to allow selective alerting for the nonzero-exitcode alert. This needs a new var, since the existing squad_log_filter is too broad (e.g. you
 may want to disable exit code alerts without disabling the others).