### PR TITLE
add validation for `success_alert_alignment_period_seconds`

### DIFF
--- a/modules/cron/variables.tf
+++ b/modules/cron/variables.tf
@@ -181,6 +181,10 @@ variable "success_alert_alignment_period_seconds" {
   description = "Alignment period for successful completion alert. 0 (default) to not create alert."
   type        = number
   default     = 0
+  validation {
+    condition     = var.success_alert_alignment_period_seconds <= 60 * 60 * 20
+    error_message = "Alignment period must be less than or equal to 20h (in seconds). Alert horizon (duration + alignment period) must be <= 25h, and duration is set to (alignment period)/4."
+  }
 }
 
 variable "enable_otel_sidecar" {


### PR DESCRIPTION
The alignment period + duration of a request can't be greater than 25h. We hardcode the duration to `alignment_period/4`, which caps how big `alignment_period` can be to `20h`. Add validation on this var to avoid pushing incorrect values unknowningly.