### PR TITLE
prober: add `deletion_protection` to the prober module

### DIFF
--- a/modules/prober/README.md
+++ b/modules/prober/README.md
@@ -100,6 +100,7 @@ No requirements.
 | <a name="input_alert_description"></a> [alert\_description](#input\_alert\_description) | Alert documentation. Use this to link to playbooks or give additional context. | `string` | `"An uptime check has failed."` | no |
 | <a name="input_base_image"></a> [base\_image](#input\_base\_image) | The base image to use for the prober. | `string` | `null` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | The CPU limit for the prober. | `string` | `"1000m"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable delete protection for the service. | `bool` | `true` | no |
 | <a name="input_dns_zone"></a> [dns\_zone](#input\_dns\_zone) | The managed DNS zone in which to create prober record sets (required for multiple locations). | `string` | `""` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | The domain of the environment to probe (required for multiple locations). | `string` | `""` | no |
 | <a name="input_egress"></a> [egress](#input\_egress) | The level of egress the prober requires. | `string` | `"ALL_TRAFFIC"` | no |

--- a/modules/prober/main.tf
+++ b/modules/prober/main.tf
@@ -37,6 +37,8 @@ module "this" {
 
   request_timeout_seconds = var.service_timeout_seconds
 
+  deletion_protection = var.deletion_protection
+
   service_account = var.service_account
   containers = {
     "prober" = {

--- a/modules/prober/variables.tf
+++ b/modules/prober/variables.tf
@@ -206,3 +206,9 @@ variable "squad" {
     error_message = "squad needs to specified or disable check by setting require_squad = false"
   }
 }
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Whether to enable delete protection for the service."
+  default     = true
+}


### PR DESCRIPTION
This commit enables `deletion_protection` to prevent probes from accidental deletion.