### PR TITLE
Remove moved blocks older than 3mo (all of them)

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -586,11 +586,6 @@ resource "google_monitoring_alert_policy" "service_failure_rate_eventing" {
   project = var.project_id
 }
 
-moved {
-  from = google_logging_metric.cloud-run-scaling-failure
-  to   = google_logging_metric.cloud-run-scaling-failure[0]
-}
-
 resource "google_logging_metric" "cloud-run-scaling-failure" {
   count = var.squad == "" ? 1 : 0
 
@@ -668,11 +663,6 @@ resource "google_monitoring_alert_policy" "cloud-run-scaling-failure" {
 
   enabled = var.enable_scaling_alerts
   project = var.project_id
-}
-
-moved {
-  from = google_logging_metric.cloud-run-failed-req
-  to   = google_logging_metric.cloud-run-failed-req[0]
 }
 
 resource "google_logging_metric" "cloud-run-failed-req" {
@@ -849,11 +839,6 @@ resource "google_monitoring_alert_policy" "cloudrun_timeout" {
   notification_channels = length(var.notification_channels) != 0 ? var.notification_channels : local.slack
 }
 
-moved {
-  from = google_logging_metric.cloudrun_timeout
-  to   = google_logging_metric.cloudrun_timeout[0]
-}
-
 resource "google_logging_metric" "cloudrun_timeout" {
   count = var.squad == "" ? 1 : 0
 
@@ -889,11 +874,6 @@ resource "google_logging_metric" "cloudrun_timeout" {
     "service_name" = "EXTRACT(resource.labels.service_name)"
     "team"         = "EXTRACT(labels.squad)"
   }
-}
-
-moved {
-  from = google_logging_metric.dockerhub_ratelimit
-  to   = google_logging_metric.dockerhub_ratelimit[0]
 }
 
 resource "google_logging_metric" "dockerhub_ratelimit" {
@@ -939,11 +919,6 @@ resource "google_logging_metric" "dockerhub_ratelimit" {
   }
 }
 
-moved {
-  from = google_logging_metric.github_ratelimit
-  to   = google_logging_metric.github_ratelimit[0]
-}
-
 resource "google_logging_metric" "github_ratelimit" {
   count = var.squad == "" ? 1 : 0
 
@@ -985,11 +960,6 @@ resource "google_logging_metric" "github_ratelimit" {
     "job_name"     = "EXTRACT(resource.labels.job_name)"
     "team"         = "EXTRACT(labels.squad)"
   }
-}
-
-moved {
-  from = google_logging_metric.r2_same_ratelimit
-  to   = google_logging_metric.r2_same_ratelimit[0]
 }
 
 resource "google_logging_metric" "r2_same_ratelimit" {

--- a/modules/bucket-events/dashboard.tf
+++ b/modules/bucket-events/dashboard.tf
@@ -60,8 +60,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -119,8 +119,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/dashboard/alerts/dashboard.tf
+++ b/modules/dashboard/alerts/dashboard.tf
@@ -42,8 +42,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -97,11 +97,6 @@ module "dashboard" {
   }
 }
 
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.trigger_dashboard.google_monitoring_dashboard.dashboard
-}
-
 output "json" {
   value = {
     for k, v in module.dashboard : k => v.json
@@ -157,9 +152,4 @@ module "trigger-dashboards" {
       tiles   = module.trigger_layout[each.key].tiles,
     }
   }
-}
-
-moved {
-  from = google_monitoring_dashboard.trigger_dashboards
-  to   = module.trigger_dashboards.google_monitoring_dashboard.dashboard
 }

--- a/modules/dashboard/job/dashboard.tf
+++ b/modules/dashboard/job/dashboard.tf
@@ -56,8 +56,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -93,8 +93,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/github-bots/main.tf
+++ b/modules/github-bots/main.tf
@@ -4,11 +4,6 @@ resource "google_service_account" "sa" {
   display_name = "Service Account for ${var.name}"
 }
 
-moved {
-  from = google_service_account.sa
-  to   = google_service_account.sa[0]
-}
-
 module "service" {
   source = "../regional-go-service"
 

--- a/modules/github-events/dashboard.tf
+++ b/modules/github-events/dashboard.tf
@@ -53,8 +53,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}

--- a/modules/regional-go-service/main.tf
+++ b/modules/regional-go-service/main.tf
@@ -5,21 +5,6 @@ terraform {
   }
 }
 
-moved {
-  from = google_project_iam_member.metrics-writer
-  to   = module.this.google_project_iam_member.metrics-writer
-}
-
-moved {
-  from = google_project_iam_member.trace-writer
-  to   = module.this.google_project_iam_member.trace-writer
-}
-
-moved {
-  from = google_project_iam_member.profiler-writer
-  to   = module.this.google_project_iam_member.profiler-writer
-}
-
 // Build each of the application images from source.
 resource "ko_build" "this" {
   for_each    = var.containers
@@ -73,19 +58,4 @@ module "this" {
   execution_environment   = var.execution_environment
 
   notification_channels = var.notification_channels
-}
-
-moved {
-  from = google_cloud_run_v2_service.this
-  to   = module.this.google_cloud_run_v2_service.this
-}
-
-moved {
-  from = google_monitoring_alert_policy.bad-rollout
-  to   = module.this.google_monitoring_alert_policy.bad-rollout
-}
-
-moved {
-  from = google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated
-  to   = module.this.google_cloud_run_v2_service_iam_member.public-services-are-unauthenticated
 }

--- a/modules/workqueue/dashboard.tf
+++ b/modules/workqueue/dashboard.tf
@@ -191,8 +191,3 @@ module "dashboard" {
     }
   }
 }
-
-moved {
-  from = google_monitoring_dashboard.dashboard
-  to   = module.dashboard.google_monitoring_dashboard.dashboard
-}


### PR DESCRIPTION
Prompt:
> Enumerate the latest release by listing the tags on the repository and picking the latest semantic version.  You can compare the current state against a prior version by diffing against a prior tag.  Any moved blocks that were not added in the diff between that tag and HEAD can be removed.  Do this for the newest tag older than 3 months now.