### PR TITLE
panic_filter: match text regex 'runtime/panic'

### DIFF
--- a/modules/alerting/README.md
+++ b/modules/alerting/README.md
@@ -47,6 +47,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_dlq_filter"></a> [dlq\_filter](#input\_dlq\_filter) | additional filter to apply to dlq alert policy | `string` | `""` | no |
 | <a name="input_enable_scaling_alerts"></a> [enable\_scaling\_alerts](#input\_enable\_scaling\_alerts) | Whether to enable scaling alerts.<br/>  When logs appear with<br/>    "The request was aborted because there was no available instance." or<br/>    "The request failed because either the HTTP response was malformed or connection to the instance had an error." | `bool` | `false` | no |
+| <a name="input_exitcode_filter"></a> [exitcode\_filter](#input\_exitcode\_filter) | additional filter to apply to exitcode alert policy | `string` | `""` | no |
 | <a name="input_failed_req_filter"></a> [failed\_req\_filter](#input\_failed\_req\_filter) | additional filter to apply to failed request alert policy | `string` | `""` | no |
 | <a name="input_failure_rate_duration"></a> [failure\_rate\_duration](#input\_failure\_rate\_duration) | duration for condition to be active before alerting | `number` | `120` | no |
 | <a name="input_failure_rate_exclude_services"></a> [failure\_rate\_exclude\_services](#input\_failure\_rate\_exclude\_services) | List of service names to exclude from the 5xx failure rate alert | `list(string)` | `[]` | no |

--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -199,8 +199,8 @@ resource "google_monitoring_alert_policy" "signal" {
 locals {
   panic_filter = <<EOF
 resource.type="cloud_run_revision" OR resource.type="cloud_run_job"
-severity=ERROR
-textPayload=~"panic: .*"
+severity>=DEFAULT
+textPayload=~"panic: .*|runtime/panic"
 ${var.panic_filter}
 ${local.squad_log_filter}
 EOF

--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -199,7 +199,7 @@ resource "google_monitoring_alert_policy" "signal" {
 locals {
   panic_filter = <<EOF
 resource.type="cloud_run_revision" OR resource.type="cloud_run_job"
-severity>=DEFAULT
+severity<=ERROR
 textPayload=~"panic: .*|runtime/panic"
 ${var.panic_filter}
 ${local.squad_log_filter}

--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -200,7 +200,7 @@ locals {
   panic_filter = <<EOF
 resource.type="cloud_run_revision" OR resource.type="cloud_run_job"
 severity<=ERROR
-textPayload=~"panic: .*|runtime/panic"
+textPayload=~"panic: .*" OR textPayload=~"runtime/panic"
 ${var.panic_filter}
 ${local.squad_log_filter}
 EOF


### PR DESCRIPTION
I propose a change to this alert to also handle runtime panics as part of the condition that fires this alert. I am not so sure we want to fire this alert even if the severity is NOT at the ERROR level. But I'd consider awkward to log panics as just info/warn log entries.

related to: https://chainguard-dev.slack.com/archives/C05CM0DM7RV/p1745920565303639