### PR TITLE
github-events: Add merged extension for merged pull requests

### DIFF
--- a/modules/github-events/internal/trampoline/server_test.go
+++ b/modules/github-events/internal/trampoline/server_test.go
@@ -345,6 +345,78 @@ func TestPullRequestExtension(t *testing.T) {
 	}
 }
 
+func TestIsPullRequestMerged(t *testing.T) {
+	testCases := []struct {
+		name      string
+		eventType string
+		payload   map[string]interface{}
+		expected  bool
+	}{
+		{
+			name:      "merged pull request",
+			eventType: "pull_request",
+			payload: map[string]interface{}{
+				"action": "closed",
+				"pull_request": map[string]interface{}{
+					"merged": true,
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "closed but not merged pull request",
+			eventType: "pull_request",
+			payload: map[string]interface{}{
+				"action": "closed",
+				"pull_request": map[string]interface{}{
+					"merged": false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name:      "open pull request",
+			eventType: "pull_request",
+			payload: map[string]interface{}{
+				"action": "opened",
+				"pull_request": map[string]interface{}{
+					"merged": false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name:      "not a pull request event",
+			eventType: "push",
+			payload: map[string]interface{}{
+				"action": "closed",
+				"pull_request": map[string]interface{}{
+					"merged": true,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Marshal the payload
+			payload, err := json.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("Failed to marshal payload: %v", err)
+			}
+
+			// Call the function
+			result := isPullRequestMerged(tc.eventType, payload)
+
+			// Check the result
+			if result != tc.expected {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestOrgFilter(t *testing.T) {
 	secret := []byte("hunter2")
 	opts := ServerOptions{


### PR DESCRIPTION
Add a new field to CloudEvents indicating when a pull request is merged.

This adds a boolean "merged" extension to events when a pull request has been merged, making it easier for downstream consumers to filter and process merged PRs without having to parse the event payload.

A filter to consume only merged PRs might look like this:

```
      filter = {
        "type"   = "dev.chainguard.github.pull_request"
        "action" = "closed"
        "merged" = "true"
      }
```