### PR TITLE
github-events: Optimize JSON unmarshalling in webhook handler

### DIFF
--- a/modules/github-events/internal/trampoline/server_test.go
+++ b/modules/github-events/internal/trampoline/server_test.go
@@ -202,16 +202,18 @@ func TestExtractPullRequestInfo(t *testing.T) {
 	testCases := []struct {
 		name      string
 		eventType string
-		payload   map[string]interface{}
+		payload   PayloadInfo
 		expected  string
 	}{
 		{
 			name:      "pull_request event with valid data",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"number": float64(123),
-				"repository": map[string]interface{}{
-					"full_name": "foo/bar",
+			payload: PayloadInfo{
+				Number: 123,
+				Repository: struct {
+					FullName string `json:"full_name,omitempty"`
+				}{
+					FullName: "foo/bar",
 				},
 			},
 			expected: "foo/bar#123",
@@ -219,10 +221,12 @@ func TestExtractPullRequestInfo(t *testing.T) {
 		{
 			name:      "not a pull_request event",
 			eventType: "push",
-			payload: map[string]interface{}{
-				"number": float64(123),
-				"repository": map[string]interface{}{
-					"full_name": "foo/bar",
+			payload: PayloadInfo{
+				Number: 123,
+				Repository: struct {
+					FullName string `json:"full_name,omitempty"`
+				}{
+					FullName: "foo/bar",
 				},
 			},
 			expected: "",
@@ -230,9 +234,11 @@ func TestExtractPullRequestInfo(t *testing.T) {
 		{
 			name:      "pull_request event with missing number",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"repository": map[string]interface{}{
-					"full_name": "foo/bar",
+			payload: PayloadInfo{
+				Repository: struct {
+					FullName string `json:"full_name,omitempty"`
+				}{
+					FullName: "foo/bar",
 				},
 			},
 			expected: "",
@@ -240,8 +246,8 @@ func TestExtractPullRequestInfo(t *testing.T) {
 		{
 			name:      "pull_request event with missing repo",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"number": float64(123),
+			payload: PayloadInfo{
+				Number: 123,
 			},
 			expected: "",
 		},
@@ -249,7 +255,7 @@ func TestExtractPullRequestInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Call the function directly with map
+			// Call the function directly
 			result := extractPullRequestInfo(tc.eventType, tc.payload)
 
 			// Check the result
@@ -343,16 +349,18 @@ func TestIsPullRequestMerged(t *testing.T) {
 	testCases := []struct {
 		name      string
 		eventType string
-		payload   map[string]interface{}
+		payload   PayloadInfo
 		expected  bool
 	}{
 		{
 			name:      "merged pull request",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"action": "closed",
-				"pull_request": map[string]interface{}{
-					"merged": true,
+			payload: PayloadInfo{
+				Action: "closed",
+				PullRequest: struct {
+					Merged bool `json:"merged,omitempty"`
+				}{
+					Merged: true,
 				},
 			},
 			expected: true,
@@ -360,10 +368,12 @@ func TestIsPullRequestMerged(t *testing.T) {
 		{
 			name:      "closed but not merged pull request",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"action": "closed",
-				"pull_request": map[string]interface{}{
-					"merged": false,
+			payload: PayloadInfo{
+				Action: "closed",
+				PullRequest: struct {
+					Merged bool `json:"merged,omitempty"`
+				}{
+					Merged: false,
 				},
 			},
 			expected: false,
@@ -371,10 +381,12 @@ func TestIsPullRequestMerged(t *testing.T) {
 		{
 			name:      "open pull request",
 			eventType: "pull_request",
-			payload: map[string]interface{}{
-				"action": "opened",
-				"pull_request": map[string]interface{}{
-					"merged": false,
+			payload: PayloadInfo{
+				Action: "opened",
+				PullRequest: struct {
+					Merged bool `json:"merged,omitempty"`
+				}{
+					Merged: false,
 				},
 			},
 			expected: false,
@@ -382,10 +394,12 @@ func TestIsPullRequestMerged(t *testing.T) {
 		{
 			name:      "not a pull request event",
 			eventType: "push",
-			payload: map[string]interface{}{
-				"action": "closed",
-				"pull_request": map[string]interface{}{
-					"merged": true,
+			payload: PayloadInfo{
+				Action: "closed",
+				PullRequest: struct {
+					Merged bool `json:"merged,omitempty"`
+				}{
+					Merged: true,
 				},
 			},
 			expected: false,

--- a/modules/github-events/internal/trampoline/server_test.go
+++ b/modules/github-events/internal/trampoline/server_test.go
@@ -209,7 +209,7 @@ func TestExtractPullRequestInfo(t *testing.T) {
 			name:      "pull_request event with valid data",
 			eventType: "pull_request",
 			payload: map[string]interface{}{
-				"number": 123,
+				"number": float64(123),
 				"repository": map[string]interface{}{
 					"full_name": "foo/bar",
 				},
@@ -220,7 +220,7 @@ func TestExtractPullRequestInfo(t *testing.T) {
 			name:      "not a pull_request event",
 			eventType: "push",
 			payload: map[string]interface{}{
-				"number": 123,
+				"number": float64(123),
 				"repository": map[string]interface{}{
 					"full_name": "foo/bar",
 				},
@@ -241,7 +241,7 @@ func TestExtractPullRequestInfo(t *testing.T) {
 			name:      "pull_request event with missing repo",
 			eventType: "pull_request",
 			payload: map[string]interface{}{
-				"number": 123,
+				"number": float64(123),
 			},
 			expected: "",
 		},
@@ -249,14 +249,8 @@ func TestExtractPullRequestInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Marshal the payload
-			payload, err := json.Marshal(tc.payload)
-			if err != nil {
-				t.Fatalf("Failed to marshal payload: %v", err)
-			}
-
-			// Call the function
-			result := extractPullRequestInfo(tc.eventType, payload)
+			// Call the function directly with map
+			result := extractPullRequestInfo(tc.eventType, tc.payload)
 
 			// Check the result
 			if result != tc.expected {
@@ -400,14 +394,8 @@ func TestIsPullRequestMerged(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Marshal the payload
-			payload, err := json.Marshal(tc.payload)
-			if err != nil {
-				t.Fatalf("Failed to marshal payload: %v", err)
-			}
-
-			// Call the function
-			result := isPullRequestMerged(tc.eventType, payload)
+			// Call the function directly
+			result := isPullRequestMerged(tc.eventType, tc.payload)
 
 			// Check the result
 			if result != tc.expected {


### PR DESCRIPTION
Reduce webhook processing overhead by unmarshalling the JSON payload once instead of four times.

This change improves performance by:

  - Parsing the payload into a generic map at the beginning
  - Update helper functions that work with already parsed data
  - Maintaining full backward compatibility
  - Preserving all existing functionality for PR and merged detection

All tests pass with the optimized implementation.