### PR TITLE
modules/cron: Don't /4 success_alert_alignment_period_seconds

### DIFF
--- a/modules/cron/main.tf
+++ b/modules/cron/main.tf
@@ -305,7 +305,7 @@ resource "google_monitoring_alert_policy" "success" {
         per_series_aligner   = "ALIGN_MAX"
       }
 
-      duration = "${ceil(var.success_alert_alignment_period_seconds / 4)}s"
+      duration = "${var.success_alert_alignment_period_seconds}s"
       trigger {
         count = "1"
       }


### PR DESCRIPTION
This is not how most callers were using this and it wasn't obvious that this value was being divided.