### PR TITLE
alert policy for cloud run job failures

### DIFF
--- a/modules/alerting/README.md
+++ b/modules/alerting/README.md
@@ -23,6 +23,7 @@ No modules.
 | [google_logging_metric.dockerhub_ratelimit](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 | [google_logging_metric.github_ratelimit](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 | [google_logging_metric.r2_same_ratelimit](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
+| [google_logging_metric.violation_metric](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 | [google_monitoring_alert_policy.bad-rollout](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.cloud-run-failed-req](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.cloud-run-scaling-failure](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
@@ -30,7 +31,8 @@ No modules.
 | [google_monitoring_alert_policy.fatal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.grpc_error_rate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.http_error_rate](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
-| [google_monitoring_alert_policy.nonzero-exitcode](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.nonzero-exitcode-job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_alert_policy.nonzero-exitcode-svc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.oom](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.panic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_alert_policy.panic-stacktrace](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |

--- a/modules/alerting/variables.tf
+++ b/modules/alerting/variables.tf
@@ -62,6 +62,12 @@ variable "exitcode_filter" {
   default     = ""
 }
 
+variable "job_exitcode_filter" {
+  description = "additional filter to apply to job exitcode alert policy"
+  type        = string
+  default     = ""
+}
+
 variable "failure_rate_ratio_threshold" {
   description = "ratio threshold to alert for cloud run server failure rate."
   type        = number


### PR DESCRIPTION
split existing exit code alert policy into two, one for service and one for jobs

service will use log message with exit code
job will use audit log for execution run to tell if it failed or not

a separate alert policy will be created for the cloud run job where we customize the exit code to differentiate between expected failures and system failures