### PR TITLE
feat: add cloudsql-postgres module

### DIFF
--- a/modules/cloudsql-postgres/README.md
+++ b/modules/cloudsql-postgres/README.md
@@ -1,0 +1,95 @@
+# Google Cloud SQL PostgreSQL Module
+
+Opinionated Terraform module that provisions a Cloud SQL for PostgreSQL instance.
+
+## Features
+
+- Creates a Cloud SQL PostgreSQL instance (defaults to PostgreSQL 17)
+- Private IP connectivity only (no public IP exposure)
+- Configurable high availability with regional failover
+- Cross-region read replica support
+- Automated backups and point-in-time recovery
+- Configurable maintenance windows
+- IAM authentication enabled by default
+- Service account access management
+- Storage autoresizing with configurable limits
+
+## Usage
+
+```hcl
+module "postgres" {
+  source = "chainguard-dev/common/infra//cloudsql-postgres"
+  name = "myapp-db"
+  project = "my-gcp-project"
+  region = "us-central1"
+  network = "projects/my-gcp-project/global/networks/my-vpc"
+  squad = "platform"
+
+  # Optional configurations
+  enable_high_availability = true
+  read_replica_regions = ["us-east1"]
+  tier = "db-custom-4-16384"
+
+  authorized_client_service_accounts = [
+    "myapp@my-gcp-project.iam.gserviceaccount.com"
+  ]
+}
+```
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 6.34.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_project_iam_member.client_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_sql_database_instance.replicas](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_database_instance.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_authorized_client_service_accounts"></a> [authorized\_client\_service\_accounts](#input\_authorized\_client\_service\_accounts) | List of Google service account emails that require `roles/cloudsql.client`. | `list(string)` | `[]` | no |
+| <a name="input_backup_enabled"></a> [backup\_enabled](#input\_backup\_enabled) | Enable automated daily backups. | `bool` | `true` | no |
+| <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | Start time for the backup window (UTC, HH:MM). | `string` | `"08:00"` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Additional database flags to set on the instance. | `map(string)` | `{}` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Cloud SQL engine version. | `string` | `"POSTGRES_17"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Cloud SQL API deletion protection flag. When true, prevents instance deletion via the API. | `bool` | `true` | no |
+| <a name="input_disk_autoresize_limit"></a> [disk\_autoresize\_limit](#input\_disk\_autoresize\_limit) | Upper GB limit for automatic storage growth. Set to 0 for unlimited. | `number` | `4096` | no |
+| <a name="input_enable_high_availability"></a> [enable\_high\_availability](#input\_enable\_high\_availability) | Enable regional high‑availability (REGIONAL availability\_type). | `bool` | `false` | no |
+| <a name="input_enable_point_in_time_recovery"></a> [enable\_point\_in\_time\_recovery](#input\_enable\_point\_in\_time\_recovery) | Enable point‑in‑time recovery (continuous WAL archiving). | `bool` | `true` | no |
+| <a name="input_maintenance_window_day"></a> [maintenance\_window\_day](#input\_maintenance\_window\_day) | Day of week for maintenance window (1=Mon … 7=Sun, 0 for unspecified). | `number` | `7` | no |
+| <a name="input_maintenance_window_hour"></a> [maintenance\_window\_hour](#input\_maintenance\_window\_hour) | Hour (0‑23 UTC) for the maintenance window. | `number` | `5` | no |
+| <a name="input_name"></a> [name](#input\_name) | Cloud SQL instance name (lowercase letters, numbers, and hyphens; up to 98 characters). | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | Self‑link or name of the VPC network used for private IP connectivity. | `string` | n/a | yes |
+| <a name="input_primary_zone"></a> [primary\_zone](#input\_primary\_zone) | Optional zone for the primary instance. | `string` | `null` | no |
+| <a name="input_project"></a> [project](#input\_project) | GCP project ID hosting the Cloud SQL instance. | `string` | n/a | yes |
+| <a name="input_read_replica_regions"></a> [read\_replica\_regions](#input\_read\_replica\_regions) | List of regions in which to create read replicas. Empty list for none. | `list(string)` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | GCP region for the primary instance. | `string` | n/a | yes |
+| <a name="input_require_squad"></a> [require\_squad](#input\_require\_squad) | Whether the `squad` variable must be specified. | `bool` | `true` | no |
+| <a name="input_squad"></a> [squad](#input\_squad) | Squad or team label applied to the instance. | `string` | `""` | no |
+| <a name="input_storage_gb"></a> [storage\_gb](#input\_storage\_gb) | Initial SSD storage size in GB. | `number` | `256` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | Machine tier for the Cloud SQL instance. | `string` | `"db-custom-16-131072"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_client_sa_bindings"></a> [client\_sa\_bindings](#output\_client\_sa\_bindings) | Map of service‑account email → IAM binding resource ID. |
+| <a name="output_instance_connection_name"></a> [instance\_connection\_name](#output\_instance\_connection\_name) | Fully‑qualified connection name of the primary instance (<project>:<region>:<instance>). |
+| <a name="output_instance_self_link"></a> [instance\_self\_link](#output\_instance\_self\_link) | Self‑link URI of the primary Cloud SQL instance. |
+| <a name="output_private_ip_address"></a> [private\_ip\_address](#output\_private\_ip\_address) | Private IPv4 address of the primary Cloud SQL instance. |
+| <a name="output_replica_connection_names"></a> [replica\_connection\_names](#output\_replica\_connection\_names) | Map of replica region → connection name. Empty if no replicas. |
+| <a name="output_replica_private_ips"></a> [replica\_private\_ips](#output\_replica\_private\_ips) | Map of replica region → private IPv4 address. Empty if no replicas. |

--- a/modules/cloudsql-postgres/docs/auth.md
+++ b/modules/cloudsql-postgres/docs/auth.md
@@ -1,0 +1,50 @@
+# Authentication Model for Cloud SQL PostgreSQL Module
+
+This document explains **how workloads authenticate to Cloud SQL instances provisioned by the `cloudsql‑postgres` Terraform module**, covering both GKE and non‑Kubernetes consumers. The design relies on **Cloud SQL IAM database authentication**.
+
+## Summary
+
+* **IAM database authentication** is enabled on every instance via the `cloudsql.iam_authentication` flag ([Cloud SQL IAM auth guide](https://cloud.google.com/sql/docs/postgres/iam-authentication)).
+* **Workload Identity** binds a Kubernetes Service Account (KSA) to a Google Service Account (GSA) that has `roles/cloudsql.client`; the GSA's short‑lived IAM token becomes the database credential ([GKE Workload Identity overview](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)).
+* Workloads can connect through the **Cloud SQL Auth Proxy** sidecar; this is the fully supported approach ([Auth Proxy v2 documentation](https://cloud.google.com/sql/docs/postgres/connect-auth-proxy)).
+* The module **never creates password users**; teams who need one must add a separate `google_sql_user` resource ([Managing PostgreSQL users](https://cloud.google.com/sql/docs/postgres/create-manage-users)).
+
+## 1. Connection options
+
+### 1.1. Cloud SQL Auth Proxy sidecar in GKE *(recommended)*
+
+1. **Bind KSA → GSA** with Workload Identity Federation ([binding guide](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#binding_ksa_to_gsa)).
+2. Module grants the bound **GSA** `roles/cloudsql.client` ([Cloud SQL IAM roles reference](https://cloud.google.com/sql/docs/postgres/iam-roles-permissions)).
+3. Pod runs the Auth Proxy v2 sidecar:
+
+   ```yaml
+   - name: cloud-sql-proxy
+     image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+     args: ["--private-ip", "--auto-iam-authn", "$(INSTANCE)"]
+   ```
+
+   `--auto-iam-authn` instructs the proxy to issue a fresh IAM token for each connection ([Auth Proxy v2 documentation](https://cloud.google.com/sql/docs/postgres/connect-auth-proxy)).
+4. Application connects to `localhost:5432`; no credentials are stored in the container.
+
+### 1.2. Auth Proxy on non-GKE hosts
+
+```bash
+cloud-sql-proxy --private-ip --auto-iam-authn $INSTANCE &
+psql "host=127.0.0.1 user=iam:$GSA_EMAIL sslmode=disable"
+```
+
+This method requires that the host running the Cloud SQL Auth Proxy has direct private IP connectivity to the Cloud SQL instance, meaning it must be within the same VPC network or a network connected via VPC peering or VPN. It will **not work** from local environments unless a secure network connection (e.g., VPN or Cloud Interconnect) to the Google Cloud VPC network is established.
+
+The proxy obtains IAM authentication tokens automatically using the host's Application Default Credentials or the VM's assigned service account. ([Auth Proxy guide](https://cloud.google.com/sql/docs/postgres/connect-auth-proxy))
+
+## 2. FAQs
+
+**Q – Does IAM auth work for read replicas?**
+If the `cloudsql.iam_authentication` flag is **enabled on the primary**, Cloud SQL automatically enables it on any read replicas created afterwards. If it's **disabled on the primary**, replicas can't use IAM authentication and the flag cannot be turned on later ([Read‑replica creation guide](https://cloud.google.com/sql/docs/postgres/replication/create-replica)).
+
+**Q – Which editions support IAM auth?**
+Both **Enterprise** and **Enterprise Plus** editions support IAM authentication; Cloud SQL defaults to Enterprise Plus for PostgreSQL 16+ and Enterprise for earlier versions ([Edition overview](https://cloud.google.com/sql/docs/postgres/editions-intro)).
+
+## 3. Terraform IAM examples
+
+TODO

--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -1,0 +1,136 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+# Labels
+
+locals {
+  default_labels = {
+    cloudsql = var.name
+  }
+
+  squad_label = var.squad != "" ? {
+    squad = var.squad
+    team  = var.squad
+  } : {}
+
+  merged_labels = merge(local.default_labels, local.squad_label)
+}
+
+# Primary Cloud SQL instance
+
+resource "google_sql_database_instance" "this" {
+  name    = var.name
+  project = var.project
+  region  = var.region
+
+  database_version    = var.database_version
+  deletion_protection = var.deletion_protection
+
+  settings {
+    tier                  = var.tier
+    availability_type     = var.enable_high_availability ? "REGIONAL" : "ZONAL"
+    disk_type             = "PD_SSD"
+    disk_size             = var.storage_gb
+    disk_autoresize       = true
+    disk_autoresize_limit = var.disk_autoresize_limit
+
+    # Optional edition (ENTERPRISE or ENTERPRISE_PLUS). Null lets provider use
+    # its default based on database_version.
+    edition = var.edition
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = var.network
+    }
+
+    backup_configuration {
+      enabled                        = var.backup_enabled
+      start_time                     = var.backup_start_time
+      point_in_time_recovery_enabled = var.enable_point_in_time_recovery
+    }
+
+    maintenance_window {
+      day  = var.maintenance_window_day
+      hour = var.maintenance_window_hour
+    }
+
+    dynamic "location_preference" {
+      for_each = var.primary_zone == null ? [] : [var.primary_zone]
+      content {
+        zone = location_preference.value
+      }
+    }
+
+    dynamic "database_flags" {
+      for_each = merge({
+        "cloudsql.iam_authentication" = "on"
+      }, var.database_flags)
+      content {
+        name  = database_flags.key
+        value = database_flags.value
+      }
+    }
+
+    user_labels = local.merged_labels
+  }
+
+  lifecycle {
+    # When disk_autoresize is enabled we let Cloud SQL grow storage automatically.
+    # Ignore manual size changes in Terraform to prevent overriding autosizing.
+    ignore_changes = [
+      settings[0].disk_size
+    ]
+  }
+}
+
+# Optional read replicas
+
+resource "google_sql_database_instance" "replicas" {
+  for_each = toset(var.read_replica_regions)
+
+  name                = "${var.name}-${each.value}"
+  project             = var.project
+  region              = each.value
+  database_version    = var.database_version
+  deletion_protection = true
+
+  settings {
+    tier = var.tier
+
+    # Ensure replicas use same edition as primary
+    edition = var.edition
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = var.network
+    }
+
+    user_labels = merge(local.merged_labels, {
+      replica = "true"
+      region  = each.value
+    })
+  }
+
+  lifecycle {
+    # When disk_autoresize is enabled we let Cloud SQL grow storage automatically.
+    # Ignore manual size changes in Terraform to prevent overriding autosizing.
+    ignore_changes = [
+      settings[0].disk_size
+    ]
+  }
+}
+
+# Data‑plane IAM for authorized GSAs
+
+resource "google_project_iam_member" "client_sa" {
+  for_each = toset(var.authorized_client_service_accounts)
+
+  project = var.project
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${each.value}"
+}

--- a/modules/cloudsql-postgres/outputs.tf
+++ b/modules/cloudsql-postgres/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_name" {
+  description = "Name of the primary Cloud SQL instance."
+  value       = google_sql_database_instance.this.name
+}
+
+output "instance_connection_name" {
+  description = "Fully‑qualified connection name of the primary instance (<project>:<region>:<instance>)."
+  value       = google_sql_database_instance.this.connection_name
+}
+
+output "private_ip_address" {
+  description = "Private IPv4 address of the primary Cloud SQL instance."
+  value       = google_sql_database_instance.this.private_ip_address
+}
+
+output "instance_self_link" {
+  description = "Self‑link URI of the primary Cloud SQL instance."
+  value       = google_sql_database_instance.this.self_link
+}
+
+output "replica_connection_names" {
+  description = "Map of replica region → connection name. Empty if no replicas."
+  value       = { for r, inst in google_sql_database_instance.replicas : r => inst.connection_name }
+}
+
+output "replica_private_ips" {
+  description = "Map of replica region → private IPv4 address. Empty if no replicas."
+  value       = { for r, inst in google_sql_database_instance.replicas : r => inst.private_ip_address }
+}
+
+output "client_sa_bindings" {
+  description = "Map of service‑account email → IAM binding resource ID."
+  value       = { for k, v in google_project_iam_member.client_sa : k => v.id }
+}

--- a/modules/cloudsql-postgres/variables.tf
+++ b/modules/cloudsql-postgres/variables.tf
@@ -1,0 +1,186 @@
+variable "name" {
+  description = "Cloud SQL instance name (lowercase letters, numbers, and hyphens; up to 98 characters)."
+  type        = string
+}
+
+variable "project" {
+  description = "GCP project ID hosting the Cloud SQL instance."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the primary instance."
+  type        = string
+}
+
+variable "network" {
+  description = "Self‑link or name of the VPC network used for private IP connectivity."
+  type        = string
+}
+
+variable "squad" {
+  description = "Squad or team label applied to the instance (required)."
+  type        = string
+
+  validation {
+    condition     = length(trim(var.squad, " \t\n\r")) > 0
+    error_message = "squad must be specified and non-empty."
+  }
+}
+
+# Engine & Capacity
+
+variable "database_version" {
+  description = "Cloud SQL engine version."
+  type        = string
+  default     = "POSTGRES_17"
+
+  validation {
+    condition     = can(regex("^POSTGRES_", var.database_version))
+    error_message = "database_version must begin with \"POSTGRES_\" (e.g. POSTGRES_17)."
+  }
+}
+
+# For Cloud SQL Enterprise Plus edition instances, Cloud SQL offers predefined machine types.
+# For Cloud SQL Enterprise edition instances, Cloud SQL offers predefined and custom machine types.
+# see https://cloud.google.com/sql/docs/postgres/create-instance#machine-types
+variable "edition" {
+  description = <<EOT
+    Cloud SQL edition for the instance. Accepted values:
+      • "ENTERPRISE"
+      • "ENTERPRISE_PLUS"
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.edition != null && contains([
+      "ENTERPRISE",
+      "ENTERPRISE_PLUS"
+    ], upper(var.edition))
+
+    error_message = "edition must be explicitly set to ENTERPRISE or ENTERPRISE_PLUS."
+  }
+}
+
+# https://cloud.google.com/sql/docs/postgres/machine-series-overview
+variable "tier" {
+  description = "Machine tier for the Cloud SQL instance."
+  type        = string
+  default     = "db-perf-optimized-N-16" # 16 vCPUs, 128GB RAM
+}
+
+variable "storage_gb" {
+  description = "Initial SSD storage size in GB."
+  type        = number
+  default     = 256
+}
+
+variable "disk_autoresize_limit" {
+  description = "Upper GB limit for automatic storage growth. Set to 0 for unlimited."
+  type        = number
+  default     = 4096
+}
+
+# Availability & Replication
+
+variable "enable_high_availability" {
+  description = "Enable regional high‑availability (REGIONAL availability_type)."
+  type        = bool
+  default     = false
+}
+
+variable "primary_zone" {
+  description = "Optional zone for the primary instance."
+  type        = string
+  default     = null
+}
+
+variable "read_replica_regions" {
+  description = "List of regions in which to create read replicas. Empty list for none."
+  type        = list(string)
+  default     = []
+}
+
+# Backup & Maintenance
+
+variable "backup_enabled" {
+  description = "Enable automated daily backups."
+  type        = bool
+  default     = true
+
+  validation {
+    condition = var.backup_enabled || (
+      var.enable_high_availability == false && length(var.read_replica_regions) == 0
+    )
+    error_message = "backup_enabled must be true when high availability or read replicas are enabled."
+  }
+}
+
+variable "enable_point_in_time_recovery" {
+  description = "Enable point-in-time recovery (continuous WAL archiving)."
+  type        = bool
+  default     = true
+
+  validation {
+    condition = var.enable_point_in_time_recovery || (
+      var.enable_high_availability == false && length(var.read_replica_regions) == 0
+    )
+    error_message = "enable_point_in_time_recovery must be true when high availability or read replicas are enabled."
+  }
+}
+
+variable "backup_start_time" {
+  description = "Start time for the backup window (UTC, HH:MM)."
+  type        = string
+  default     = "08:00"
+
+  validation {
+    condition     = can(regex("^([01][0-9]|2[0-3]):[0-5][0-9]$", var.backup_start_time))
+    error_message = "backup_start_time must be in HH:MM 24‑hour format (UTC)."
+  }
+}
+
+variable "maintenance_window_day" {
+  description = "Day of week for maintenance window (1=Mon … 7=Sun, 0 for unspecified)."
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.maintenance_window_day >= 0 && var.maintenance_window_day <= 7
+    error_message = "maintenance_window_day must be between 0 and 7."
+  }
+}
+
+variable "maintenance_window_hour" {
+  description = "Hour (0‑23 UTC) for the maintenance window."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.maintenance_window_hour >= 0 && var.maintenance_window_hour <= 23
+    error_message = "maintenance_window_hour must be between 0 and 23."
+  }
+}
+
+# Advanced Configuration
+
+variable "database_flags" {
+  description = "Additional database flags to set on the instance."
+  type        = map(string)
+  default     = {}
+}
+
+variable "authorized_client_service_accounts" {
+  description = "List of Google service account emails that require `roles/cloudsql.client`."
+  type        = list(string)
+  default     = []
+}
+
+# Lifecycle & Protection
+
+variable "deletion_protection" {
+  description = "Cloud SQL API deletion protection flag. When true, prevents instance deletion via the API."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This module provisions a Cloud SQL for PostgreSQL instance with production-ready defaults and convenient toggles for high-availability, automated backups, point-in-time recovery (PITR) and read-replicas.