### PR TITLE
feat: add bastion module

### DIFF
--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -1,0 +1,173 @@
+# `bastion`
+
+A hardened IAP-only jump-host. It comes with Google Cloud Ops Agent,
+`auditd`, weekly OS patching, and optionally the **Cloud SQL Auth Proxy v2
+binary** for database (MySQL/PostgreSQL) connectivity when needed.
+
+## Key Features
+
+* **Zero-trust SSH** – IAP tunnel + OS Login (no public IP)
+* **Hardened VM** – Shielded VM, secure-boot, auditd, Ops Agent metrics & logs
+* **Optional Cloud SQL support** – Installs Cloud SQL Auth Proxy v2 binary
+  when `install_sql_proxy = true`
+* **Automatic patching** – Weekly OS Config patch deployment with reboot
+* **Dedicated NAT** – Optional Cloud NAT router for outbound security updates
+
+## Quick Start
+
+### Basic jump-host (no Cloud SQL)
+```hcl
+module "bastion" {
+  source = "github.com/chainguard-dev/terraform-infra-common//modules/bastion"
+
+  name       = "jump-host"
+  project_id = "my-project"
+  zone       = "us-central1-a"
+  network    = "projects/my-project/global/networks/my-vpc"
+  subnetwork = "my-private-subnet"
+  squad      = "platform"
+
+  # IAM principals granted OS Login access
+  dev_principals = ["group:engineering@my-company.com"]
+
+  # No Cloud SQL tooling (default)
+  install_sql_proxy = false
+}
+```
+
+### Jump-host with Cloud SQL Auth Proxy
+```hcl
+module "bastion" {
+  source = "github.com/chainguard-dev/terraform-infra-common//modules/bastion"
+
+  name       = "sql-bastion"
+  project_id = "my-project"
+  zone       = "us-central1-a"
+  network    = "projects/my-project/global/networks/my-vpc"
+  subnetwork = "my-private-subnet"
+  squad      = "platform"
+
+  # IAM principals granted OS Login & Cloud SQL access
+  dev_principals = ["group:db-breakglass@my-company.com"]
+
+  # Install the Cloud SQL Auth Proxy binary
+  install_sql_proxy = true
+}
+```
+
+## Security Model
+
+### Access Control
+- **IAP tunnel**: All SSH connections go through Identity-Aware Proxy
+- **OS Login**: Users must have `compute.osLogin` role
+- **Cloud SQL IAM** (optional): When enabled, users need `cloudsql.client` and
+  `cloudsql.instanceUser` roles
+- **Minimal SA** The bastion runs a minimal SA for metrics and logging purposes.
+  This SA is not granted `cloudsql` roles. Human users connect via Group-based IAM.
+
+### Auditing & Monitoring
+- **Command auditing**: `auditd` logs all executed commands
+- **Cloud Logging**: Startup scripts and system events
+- **Cloud Monitoring**: VM metrics via Ops Agent
+- **Secure boot**: Shielded VM prevents unauthorized boot modifications
+
+### Network Security
+- **No public IP**: VM only has private IP address
+- **IAP-only SSH**: Firewall only allows SSH from IAP IP ranges (`35.235.240.0/20`)
+- **Optional NAT**: Dedicated Cloud NAT for outbound package updates
+
+### Automatic Patching
+- **Schedule**: Weekly patching on configurable day/time (default: Monday 03:00 UTC)
+- **Reboot**: Always reboots after patching to ensure kernel updates
+- **OS Config**: Uses Google Cloud OS Config for patch management
+
+## Using the Auth Proxy
+
+SSH into the bastion and auth with gcloud:
+
+```bash
+$ gcloud compute ssh sql-bastion --tunnel-through-iap --project=<PROJECT> --zone=<ZONE>
+
+user@bastion $ gcloud auth application-default login --quiet
+```
+
+Start the Auth Proxy on the bastion:
+
+```bash
+user@bastion $ cloud-sql-proxy --auto-iam-authn --private-ip <PROJECT>:<REGION>:<INSTANCE ID>
+```
+
+In a different terminal tab, open a tunnel:
+
+```bash
+$ gcloud compute ssh sql-bastion --tunnel-through-iap --project=<PROJECT> --zone=<ZONE> -- -N -L 15432:127.0.0.1:5432
+```
+
+In a third terminal tab, you can now connect to the DB:
+
+```bash
+$ psql "host=127.0.0.1 port=15432 user=<YOU>@chainguard.dev dbname=<DB NAME>"  # Postgres example
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_firewall.iap_ssh](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_instance.bastion](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+| [google_compute_router.nat_router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.bastion_nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_os_config_patch_deployment.bastion_patching](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/os_config_patch_deployment) | resource |
+| [google_project_iam_member.bastion_extra_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.bastion_sa_log_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.bastion_sa_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.dev_cloudsql_client](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.dev_cloudsql_instance_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.dev_os_login](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.os_config_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.bastion_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | GCE API deletion protection flag. When true, prevents instance deletion via the API. | `bool` | `true` | no |
+| <a name="input_dev_principals"></a> [dev\_principals](#input\_dev\_principals) | IAM principals (users, groups, or service accounts) granted OS Login & Cloud SQL access. | `list(string)` | n/a | yes |
+| <a name="input_enable_nat"></a> [enable\_nat](#input\_enable\_nat) | Whether to create a dedicated Cloud NAT router for outbound egress. Disable when VPC already has NAT. | `bool` | `true` | no |
+| <a name="input_extra_sa_roles"></a> [extra\_sa\_roles](#input\_extra\_sa\_roles) | Additional IAM roles to bind to the bastion's service account. | `list(string)` | `[]` | no |
+| <a name="input_install_sql_proxy"></a> [install\_sql\_proxy](#input\_install\_sql\_proxy) | Whether to install the Cloud SQL Auth Proxy binary and grant associated IAM permissions. | `bool` | `false` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Engine machine type for the bastion. | `string` | `"e2-micro"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name prefix for all resources (also used as network tag). | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | VPC network self-link or name the bastion joins. | `string` | n/a | yes |
+| <a name="input_patch_day"></a> [patch\_day](#input\_patch\_day) | Day of week (in UTC) when OS Config patching runs. | `string` | `"MONDAY"` | no |
+| <a name="input_patch_time_utc"></a> [patch\_time\_utc](#input\_patch\_time\_utc) | Time of day in HH:MM (UTC) when patching runs. | `string` | `"03:00"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which to deploy the bastion host. | `string` | n/a | yes |
+| <a name="input_squad"></a> [squad](#input\_squad) | Squad or team label applied to the instance (required). | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnetwork name the bastion joins (must be private). | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Compute Engine zone for the bastion VM (e.g. us-central1-a). | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | Name of the bastion compute instance |
+| <a name="output_internal_ip"></a> [internal\_ip](#output\_internal\_ip) | Internal IP address of the bastion VM |
+| <a name="output_nat_router_name"></a> [nat\_router\_name](#output\_nat\_router\_name) | Name of the Cloud NAT router (empty when enable\_nat = false) |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Service account email used by the bastion |
+| <a name="output_ssh_target_tag"></a> [ssh\_target\_tag](#output\_ssh\_target\_tag) | Network tag applied to the bastion for SSH firewall rules |
+<!-- END_TF_DOCS -->

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -1,0 +1,277 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+resource "google_project_service" "os_config_api" {
+  project            = var.project_id
+  service            = "osconfig.googleapis.com"
+  disable_on_destroy = false
+}
+
+locals {
+  // Derive region from zone (e.g. us-central1-a -> us-central1)
+  region        = join("-", slice(split("-", var.zone), 0, 2))
+  instance_name = substr(var.name, 0, 63) # GCE name limit
+  instance_tag  = var.name
+
+  // Labels
+  default_labels = {
+    bastion = var.name
+  }
+
+  squad_label = {
+    squad = var.squad
+    team  = var.squad
+  }
+
+  merged_labels = merge(local.default_labels, local.squad_label)
+
+  // Split patch time HH:MM into components
+  patch_hour   = tonumber(split(":", var.patch_time_utc)[0])
+  patch_minute = tonumber(split(":", var.patch_time_utc)[1])
+
+  // Optional Cloud SQL Auth Proxy binary install
+  proxy_install_script = <<-PROXY
+      # ------------------------------------------------------
+      # Install Cloud SQL Auth Proxy v2 (binary only)
+      # ------------------------------------------------------
+      curl -sSL -o /usr/local/bin/cloud-sql-proxy \
+        https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.16.0/cloud-sql-proxy.linux.amd64
+      chmod +x /usr/local/bin/cloud-sql-proxy
+  PROXY
+
+  bastion_startup = join("\n", compact([
+    <<-SCRIPT
+      #!/usr/bin/env bash
+      set -euo pipefail
+    SCRIPT
+    ,
+
+    <<-AUDIT
+      apt-get update -y
+      apt-get install -y auditd
+      systemctl enable --now auditd.service
+
+      cat > /etc/audit/rules.d/99-bastion.rules <<'AUDITD'
+      -w /usr/bin/ -p x -k execs
+      -w /bin/ -p x -k execs
+      -a always,exit -F arch=b64 -S execve -k execs
+      AUDITD
+
+      augenrules --load
+    AUDIT
+    ,
+
+    <<-COMMON
+      # ------------------------------------------------------
+      # Install Google Cloud Ops Agent for logging & metrics
+      # ------------------------------------------------------
+      curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+      bash add-google-cloud-ops-agent-repo.sh --also-install
+    COMMON
+    ,
+
+    // Optionally install Cloud SQL Auth Proxy
+    var.install_sql_proxy ? local.proxy_install_script : "",
+  ]))
+}
+
+// -----------------------------------------------------------------------------
+// Compute Engine VM
+// -----------------------------------------------------------------------------
+
+resource "google_compute_instance" "bastion" {
+  name         = local.instance_name
+  project      = var.project_id
+  zone         = var.zone
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-12"
+    }
+  }
+
+  shielded_instance_config {
+    enable_secure_boot          = true
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  network_interface {
+    network            = var.network
+    subnetwork         = var.subnetwork
+    subnetwork_project = var.project_id
+  }
+
+  service_account {
+    email = google_service_account.bastion_sa.email
+    scopes = concat(
+      var.install_sql_proxy ? ["https://www.googleapis.com/auth/sqlservice.admin"] : [],
+      [
+        "https://www.googleapis.com/auth/logging.write",
+        "https://www.googleapis.com/auth/monitoring.write",
+      ]
+    )
+  }
+
+  metadata = {
+    enable-oslogin         = "TRUE"
+    block-project-ssh-keys = "TRUE"
+  }
+
+  metadata_startup_script = local.bastion_startup
+
+  tags = [local.instance_tag]
+
+  allow_stopping_for_update = true
+
+  deletion_protection = var.deletion_protection
+
+  labels = local.merged_labels
+}
+
+// -----------------------------------------------------------------------------
+// IAP-only SSH firewall rule
+// -----------------------------------------------------------------------------
+
+resource "google_compute_firewall" "iap_ssh" {
+  name    = "allow-iap-ssh-${var.name}"
+  project = var.project_id
+  network = var.network
+
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = [local.instance_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+// -----------------------------------------------------------------------------
+// OS Config patch deployment
+// -----------------------------------------------------------------------------
+
+resource "google_os_config_patch_deployment" "bastion_patching" {
+  project             = var.project_id
+  patch_deployment_id = "${var.name}-weekly-patching"
+
+  instance_filter {
+    instance_name_prefixes = [google_compute_instance.bastion.name]
+  }
+
+  recurring_schedule {
+    time_zone {
+      id = "Etc/UTC"
+    }
+
+    weekly {
+      day_of_week = upper(var.patch_day)
+    }
+
+    time_of_day {
+      hours   = local.patch_hour
+      minutes = local.patch_minute
+      seconds = 0
+      nanos   = 0
+    }
+  }
+
+  patch_config {
+    reboot_config = "ALWAYS"
+  }
+
+  depends_on = [google_project_service.os_config_api]
+}
+
+// -----------------------------------------------------------------------------
+// Cloud NAT (optional)
+// -----------------------------------------------------------------------------
+
+resource "google_compute_router" "nat_router" {
+  count   = var.enable_nat ? 1 : 0
+  name    = "${var.project_id}-${var.name}-nat-router"
+  project = var.project_id
+  region  = local.region
+  network = var.network
+}
+
+resource "google_compute_router_nat" "bastion_nat" {
+  count   = var.enable_nat ? 1 : 0
+  name    = "${var.project_id}-${var.name}-nat"
+  project = var.project_id
+  region  = local.region
+  router  = google_compute_router.nat_router[count.index].name
+
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = var.subnetwork
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Service account and IAM
+// -----------------------------------------------------------------------------
+
+resource "google_service_account" "bastion_sa" {
+  project      = var.project_id
+  account_id   = "${var.name}-sa"
+  display_name = "Service account for ${var.name} bastion"
+}
+
+resource "google_project_iam_member" "bastion_sa_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.bastion_sa.email}"
+}
+
+resource "google_project_iam_member" "bastion_sa_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.bastion_sa.email}"
+}
+
+resource "google_project_iam_member" "bastion_extra_roles" {
+  for_each = toset(var.extra_sa_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.bastion_sa.email}"
+}
+
+// -----------------------------------------------------------------------------
+// Developer IAM access
+// -----------------------------------------------------------------------------
+
+resource "google_project_iam_member" "dev_os_login" {
+  for_each = toset(var.dev_principals)
+  project  = var.project_id
+  role     = "roles/compute.osLogin"
+  member   = each.key
+}
+
+resource "google_project_iam_member" "dev_cloudsql_client" {
+  count   = var.install_sql_proxy ? length(distinct(var.dev_principals)) : 0
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = distinct(var.dev_principals)[count.index]
+}
+
+resource "google_project_iam_member" "dev_cloudsql_instance_user" {
+  count   = var.install_sql_proxy ? length(distinct(var.dev_principals)) : 0
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = distinct(var.dev_principals)[count.index]
+}

--- a/modules/bastion/outputs.tf
+++ b/modules/bastion/outputs.tf
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+output "internal_ip" {
+  description = "Internal IP address of the bastion VM"
+  value       = google_compute_instance.bastion.network_interface[0].network_ip
+}
+
+output "instance_name" {
+  description = "Name of the bastion compute instance"
+  value       = google_compute_instance.bastion.name
+}
+
+output "service_account_email" {
+  description = "Service account email used by the bastion"
+  value       = google_service_account.bastion_sa.email
+}
+
+output "ssh_target_tag" {
+  description = "Network tag applied to the bastion for SSH firewall rules"
+  value       = local.instance_tag
+}
+
+output "nat_router_name" {
+  description = "Name of the Cloud NAT router (empty when enable_nat = false)"
+  value       = var.enable_nat ? google_compute_router_nat.bastion_nat[0].name : ""
+}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+variable "name" {
+  description = "Name prefix for all resources (also used as network tag)."
+  type        = string
+}
+
+variable "project_id" {
+  description = "Project in which to deploy the bastion host."
+  type        = string
+}
+
+variable "zone" {
+  description = "Compute Engine zone for the bastion VM (e.g. us-central1-a)."
+  type        = string
+}
+
+variable "network" {
+  description = "VPC network self-link or name the bastion joins."
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Subnetwork name the bastion joins (must be private)."
+  type        = string
+}
+
+variable "dev_principals" {
+  description = "IAM principals (users, groups, or service accounts) granted OS Login & Cloud SQL access."
+  type        = list(string)
+}
+
+variable "squad" {
+  description = "Squad or team label applied to the instance (required)."
+  type        = string
+
+  validation {
+    condition     = length(trim(var.squad, " \t\n\r")) > 0
+    error_message = "squad must be specified and non-empty."
+  }
+}
+
+variable "machine_type" {
+  description = "Compute Engine machine type for the bastion."
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "extra_sa_roles" {
+  description = "Additional IAM roles to bind to the bastion's service account."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_nat" {
+  description = "Whether to create a dedicated Cloud NAT router for outbound egress. Disable when VPC already has NAT."
+  type        = bool
+  default     = true
+}
+
+variable "patch_day" {
+  description = "Day of week (in UTC) when OS Config patching runs."
+  type        = string
+  default     = "MONDAY"
+  validation {
+    condition     = contains(["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"], upper(var.patch_day))
+    error_message = "patch_day must be a valid weekday name."
+  }
+}
+
+variable "patch_time_utc" {
+  description = "Time of day in HH:MM (UTC) when patching runs."
+  type        = string
+  default     = "03:00"
+  validation {
+    condition     = can(regex("^([01][0-9]|2[0-3]):[0-5][0-9]$", var.patch_time_utc))
+    error_message = "patch_time_utc must be in HH:MM 24-hour format."
+  }
+}
+
+variable "deletion_protection" {
+  description = "GCE API deletion protection flag. When true, prevents instance deletion via the API."
+  type        = bool
+  default     = true
+}
+
+variable "install_sql_proxy" {
+  description = "Whether to install the Cloud SQL Auth Proxy binary and grant associated IAM permissions."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Generic jump-host (bastion) module. The primary use case is to provide controlled, break-glass access to resources within a VPC that do not expose a public IP.

Includes an option to install the Cloud SQL Auth Proxy for secure, IAM-based access to Cloud SQL instances, but this is disabled by default. Otherwise, it's generic by design and isn't tied to any specific backend or service.

Needed for https://github.com/chainguard-dev/internal-dev/issues/12794, https://github.com/chainguard-dev/internal-dev/issues/12795