### PR TITLE
postgres: enforce ssl

### DIFF
--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -46,6 +46,7 @@ resource "google_sql_database_instance" "this" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network
+      ssl_mode        = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
 
     backup_configuration {
@@ -108,6 +109,7 @@ resource "google_sql_database_instance" "replicas" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network
+      ssl_mode        = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
 
     user_labels = merge(local.merged_labels, {


### PR DESCRIPTION
like we do in the datastore module, so that any client that tries to connect straight to the instance’s private IP (bypassing the auth proxy) will now be rejected unless it presents a valid client certificate.