### PR TITLE
add support for pull_request_target

### DIFF
--- a/modules/github-gsa/main.tf
+++ b/modules/github-gsa/main.tf
@@ -70,6 +70,17 @@ locals {
     "true",
   ])}"
 
+  pull-request-target = "attribute.pullrequesttarget/${join("|", [
+    var.repository,
+    "true",
+    "${var.repository}/${var.workflow_ref}",
+  ])}"
+
+  pull-request-target-any-workflow = "attribute.pullrequesttargetanyworkflow/${join("|", [
+    var.repository,
+    "true",
+  ])}"
+
   version-tags = "attribute.versiontags/${join("|", [
     var.repository,
     "true",
@@ -95,21 +106,29 @@ locals {
         local.pull-request
       )
       ) : (
-      var.refspec == "version_tags" ? (
+      var.refspec == "pull_request_target" ? (
         var.workflow_ref == "*" ? (
-          local.version-tags-any-workflow
+          local.pull-request-target-any-workflow
           ) : (
-          local.version-tags
+          local.pull-request-target
         )
         ) : (
-        var.workflow_ref == "*" ? (
-          local.exact-any-workflow
+        var.refspec == "version_tags" ? (
+          var.workflow_ref == "*" ? (
+            local.version-tags-any-workflow
+            ) : (
+            local.version-tags
+          )
           ) : (
-          local.exact
+          var.workflow_ref == "*" ? (
+            local.exact-any-workflow
+            ) : (
+            local.exact
+          )
         )
       )
-    )
-  )
+  ))
+
 }
 
 // Create the IAM binding allowing workflows to impersonate the service account.

--- a/modules/github-gsa/variables.tf
+++ b/modules/github-gsa/variables.tf
@@ -21,8 +21,8 @@ variable "refspec" {
   description = "The refspec to allow to federate with this identity."
   type        = string
   validation {
-    condition     = var.refspec == "*" || var.refspec == "pull_request" || var.refspec == "version_tags" || startswith(var.refspec, "refs/")
-    error_message = "Expected '*', 'pull_request', 'version_tags' or a refspec of the form 'refs/heads/main', but got '${var.refspec}'."
+    condition     = var.refspec == "*" || var.refspec == "pull_request" || var.refspec == "pull_request_target" || var.refspec == "version_tags" || startswith(var.refspec, "refs/")
+    error_message = "Expected '*', 'pull_request', 'pull_request_target', 'version_tags' or a refspec of the form 'refs/heads/main', but got '${var.refspec}'."
   }
 }
 variable "audit_refspec" {

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -21,7 +21,7 @@ resource "google_iam_workload_identity_pool_provider" "this" {
   attribute_mapping = {
     # Don't use the GitHub subject because it it less specific than ours, which also captures:
     #   - The pull request number via `refs/pull/N/merge`, and
-    #   - The worflow file.
+    #   - The workflow file.
     # We don't include assertion.repository because it is redundant with the prefix on assertion.workflow_ref.
     # We use assertion.ref instead of the ref included in workflow_ref so that we get the PR number on pull_request_target PRs.
     "google.subject" = "assertion.workflow_ref.split('@')[0] + '|' + assertion.ref"
@@ -40,6 +40,8 @@ resource "google_iam_workload_identity_pool_provider" "this" {
     "attribute.exactanyworkflow"       = "assertion.repository + '|' + assertion.ref"
     "attribute.pullrequest"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.pullrequestanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false')"
+    "attribute.pullrequesttarget"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/heads/main$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.pullrequesttargetanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/heads/main$') ? 'true' : 'false')"
     "attribute.versiontags"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.versiontagsanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false')"
   }

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -40,8 +40,8 @@ resource "google_iam_workload_identity_pool_provider" "this" {
     "attribute.exactanyworkflow"       = "assertion.repository + '|' + assertion.ref"
     "attribute.pullrequest"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.pullrequestanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false')"
-    "attribute.pullrequesttarget"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/heads/main$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
-    "attribute.pullrequesttargetanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/heads/main$') ? 'true' : 'false')"
+    "attribute.pullrequesttarget"            = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.pullrequesttargetanyworkflow" = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main') ? 'true' : 'false')"
     "attribute.versiontags"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.versiontagsanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false')"
   }

--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -40,8 +40,8 @@ resource "google_iam_workload_identity_pool_provider" "this" {
     "attribute.exactanyworkflow"       = "assertion.repository + '|' + assertion.ref"
     "attribute.pullrequest"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.pullrequestanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/pull/[0-9]+/merge$') ? 'true' : 'false')"
-    "attribute.pullrequesttarget"            = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
-    "attribute.pullrequesttargetanyworkflow" = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main') ? 'true' : 'false')"
+    "attribute.pullrequesttarget"            = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main' ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
+    "attribute.pullrequesttargetanyworkflow" = "assertion.repository + '|' + (assertion.ref == 'refs/heads/main' ? 'true' : 'false')"
     "attribute.versiontags"            = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false') + '|' + assertion.workflow_ref.split('@')[0]"
     "attribute.versiontagsanyworkflow" = "assertion.repository + '|' + (assertion.ref.matches('^refs/tags/v[0-9]+([.][0-9]+([.][0-9]+)?)?$') ? 'true' : 'false')"
   }


### PR DESCRIPTION
the existing refspec `pull_request` does not work with workflows triggered on `pull_request_target` as the ref for `pull_request` is of the format `refs/pull/[0-9]+/merge` while `pull_request_target` have a ref of the format `refs/heads/[BASE BRANCH]`

for https://github.com/chainguard-dev/terraform-infra-common/issues/746