### PR TITLE
redis: automatically manage AUTH credentials in Secret Manager

### DIFF
--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -39,7 +39,7 @@ module "redis" {
   # Auth configuration
   auth_enabled = true  # Auth credentials will automatically be stored in Secret Manager
 
-  service_account_email = "my-service@my-project-id.iam.gserviceaccount.com"
+  secret_accessor_sa_email = "my-service@my-project-id.iam.gserviceaccount.com"
 
   # Automated backups
   persistence_config = {
@@ -138,7 +138,7 @@ limitations under the License.
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number of replica nodes. | `number` | `0` | no |
 | <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | The CIDR range of internal addresses that are reserved for this instance. | `string` | `null` | no |
 | <a name="input_secret_version_adder"></a> [secret\_version\_adder](#input\_secret\_version\_adder) | The user allowed to populate new redis auth secret versions. | `string` | n/a | yes |
-| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the service account that will access the secret. | `string` | n/a | yes |
+| <a name="input_secret_accessor_sa_email"></a> [secret\_accessor\_sa\_email](#input\_secret\_accessor\_sa\_email) | The email of the service account that will access the secret. | `string` | n/a | yes |
 | <a name="input_squad"></a> [squad](#input\_squad) | Squad or team label applied to the instance (required). | `string` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | The service tier of the instance. Valid values: BASIC, STANDARD\_HA. | `string` | `"STANDARD_HA"` | no |
 | <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | The TLS mode of the Redis instance. Valid values: DISABLED, SERVER\_AUTHENTICATION. | `string` | `"SERVER_AUTHENTICATION"` | no |

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -46,22 +46,22 @@ resource "google_project_service" "redis_api" {
 resource "google_redis_instance" "default" {
   depends_on = [google_project_service.redis_api]
 
-  name           = var.name
-  project        = var.project_id
-  region         = var.region
-  location_id    = var.zone
+  name        = var.name
+  project     = var.project_id
+  region      = var.region
+  location_id = var.zone
 
-  tier                    = var.tier
-  memory_size_gb          = var.memory_size_gb
-  redis_version           = var.redis_version
-  reserved_ip_range       = var.reserved_ip_range
+  tier              = var.tier
+  memory_size_gb    = var.memory_size_gb
+  redis_version     = var.redis_version
+  reserved_ip_range = var.reserved_ip_range
 
   connect_mode            = var.connect_mode
   auth_enabled            = var.auth_enabled
   transit_encryption_mode = var.transit_encryption_mode
 
-  read_replicas_mode      = var.read_replicas_mode
-  replica_count           = var.replica_count
+  read_replicas_mode = var.read_replicas_mode
+  replica_count      = var.replica_count
 
   # Alternative location for HA setup
   alternative_location_id = var.alternative_location_id != "" ? var.alternative_location_id : null
@@ -98,7 +98,7 @@ resource "google_project_iam_member" "redis_client_sa" {
   for_each = toset(var.authorized_client_service_accounts)
 
   project = var.project_id
-  role    = "roles/redis.viewer"  # Read-only access by default
+  role    = "roles/redis.viewer" # Read-only access by default
   member  = "serviceAccount:${each.value}"
 }
 
@@ -106,6 +106,30 @@ resource "google_project_iam_member" "redis_editor_sa" {
   for_each = toset(var.authorized_client_editor_service_accounts)
 
   project = var.project_id
-  role    = "roles/redis.editor"  # Read-write access
+  role    = "roles/redis.editor" # Read-write access
   member  = "serviceAccount:${each.value}"
+}
+
+# Create Secret Manager secret for the auth string
+module "redis_auth_secret" {
+  source = "../secret"
+  count  = var.auth_enabled ? 1 : 0
+
+  project_id = var.project_id
+  name       = "${var.name}-auth"
+
+  service-account       = var.service_account_email
+  authorized-adder      = var.secret_version_adder
+  notification-channels = var.notification_channels
+
+  create_placeholder_version = false
+}
+
+# Create the initial version of the secret with the auth string
+resource "google_secret_manager_secret_version" "auth_string" {
+  count  = var.auth_enabled ? 1 : 0
+  secret = module.redis_auth_secret[0].secret_id
+
+  # Use the auth_string that GCP auto-generates
+  secret_data = google_redis_instance.default.auth_string
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -118,7 +118,7 @@ module "redis_auth_secret" {
   project_id = var.project_id
   name       = "${var.name}-auth"
 
-  service-account       = var.service_account_email
+  service-account       = var.secret_accessor_sa_email
   authorized-adder      = var.secret_version_adder
   notification-channels = var.notification_channels
 

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -69,3 +69,13 @@ output "rdb_snapshot_period" {
   description = "The snapshot period for RDB persistence."
   value       = var.persistence_config.persistence_mode == "RDB" ? var.persistence_config.rdb_snapshot_period : null
 }
+
+output "auth_secret_id" {
+  description = "The ID of the Secret Manager secret containing the Redis AUTH string"
+  value       = var.auth_enabled ? module.redis_auth_secret[0].secret_id : null
+}
+
+output "auth_enabled" {
+  description = "Whether AUTH is enabled for the Redis instance"
+  value       = var.auth_enabled
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -197,7 +197,7 @@ variable "authorized_client_editor_service_accounts" {
   default     = []
 }
 
-variable "service_account_email" {
+variable "secret_accessor_sa_email" {
   description = "The email of the service account that will access the secret."
   type        = string
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -145,7 +145,7 @@ variable "persistence_config" {
     rdb_snapshot_period = optional(string)
   })
   default = {
-    persistence_mode    = "DISABLED"
+    persistence_mode = "DISABLED"
   }
 
   # Check that persistence_mode is valid
@@ -195,4 +195,19 @@ variable "authorized_client_editor_service_accounts" {
   description = "List of service account emails that should be granted Redis editor (read-write) access"
   type        = list(string)
   default     = []
+}
+
+variable "service_account_email" {
+  description = "The email of the service account that will access the secret."
+  type        = string
+}
+
+variable "notification_channels" {
+  description = "List of notification channels to alert."
+  type        = list(string)
+}
+
+variable "secret_version_adder" {
+  type        = string
+  description = "The user allowed to populate new redis auth secret versions."
 }


### PR DESCRIPTION
This commit updates the module to automatically manage Redis authentication credentials in Google Secret Manager when `auth_enabled = true`:
- Create a Redis instance with authentication enabled
- Retrieve the GCP-generated auth string
- Store the auth string in Secret Manager with Secret name automatically set to `{name}-auth` (e.g., "my-redis-instance-auth")
- The Secret Manager secret is created in the same project as the Redis instance
- Make the auth string available to authorized service account