### PR TITLE
cloud-event-recorder: refactor so `writer.Close()` err is accessible to logs

### DIFF
--- a/pkg/rotate/blob.go
+++ b/pkg/rotate/blob.go
@@ -121,14 +121,15 @@ func (u *uploader) Run(ctx context.Context) error {
 
 			// retry this 3 times
 			for i := 0; i < MaxUploadAttempt; i++ {
-				if err := writer.Close(); err == nil {
+				err := writer.Close()
+				if err == nil {
 					break
 				}
 				if i == MaxUploadAttempt-1 {
 					// last attempt, no more retry
 					return fmt.Errorf("failed to close blob file: %s %w", fileName, err)
 				}
-				clog.WarnContextf(ctx, "retrying closing blog file: %s %v", fileName, err)
+				clog.WarnContextf(ctx, "retrying closing blob file: %s %v", fileName, err)
 				// wait before retrying
 				time.Sleep(RetryBackoffDuration)
 			}


### PR DESCRIPTION
We're still seeing upload errors after https://github.com/chainguard-dev/terraform-infra-common/pull/810, but the error is not accessible to the logs since it is scoped to the `if` block. Refactor so we can see the error for further debugging.