### PR TITLE
redis - add server_ca_cert output for TLS connections

### DIFF
--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -79,3 +79,8 @@ output "auth_enabled" {
   description = "Whether AUTH is enabled for the Redis instance"
   value       = var.auth_enabled
 }
+
+output "server_ca_cert" {
+  description = "The server CA certificate for the Redis instance"
+  value       = google_redis_instance.default.server_ca_certs
+}


### PR DESCRIPTION
Exposes the server CA certificates for the Redis instance as an output