### PR TITLE
fix: gke - set default of pod_ipv4_cidr_block to null to prevent invalid empty string

### DIFF
--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -67,7 +67,7 @@ variable "pools" {
     network_config = optional(object({
       enable_private_nodes = optional(bool, false)
       create_pod_range     = optional(bool, true)
-      pod_ipv4_cidr_block  = optional(string, "")
+      pod_ipv4_cidr_block  = optional(string, null)
     }), null)
   }))
 }


### PR DESCRIPTION
Change the default value for the `pod_ipv4_cidr_block` variable in `modules/gke/variables.tf` from `""` (empty string) to `null`.

When the default is set to `""` (empty string), any configuration value of `null` gets converted to an empty string by Terraform because of `optional(string, "")`. The Google provider rejects an empty string for this field, expecting either a valid CIDR block or no value at all (`null`). By setting the default to `null`, we allow the variable to be truly unset if not specified, which aligns with provider expectations and prevents errors.