### PR TITLE
add input variable `additional-service-account-accessors` to `module/secret`

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -118,13 +118,16 @@ module "redis_auth_secret" {
   project_id = var.project_id
   name       = "${var.name}-auth"
 
-  service-account       = var.secret_accessor_sa_email
   authorized-adder      = var.secret_version_adder
   notification-channels = var.notification_channels
 
   # Additional viewer/editor service accounts will need to access the
   # secret to retrieve the auth string to establish a connection
-  additional-service-account-accessors = concat(var.authorized_client_service_accounts, var.authorized_client_editor_service_accounts)
+  service-accounts = concat(
+    [var.secret_accessor_sa_email],
+    var.authorized_client_service_accounts,
+    var.authorized_client_editor_service_accounts,
+  )
 
   create_placeholder_version = false
 }

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -87,13 +87,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional-service-account-accessors"></a> [additional-service-account-accessors](#input\_additional-service-account-accessors) | Additional service accounts that will need to access the secret. | `list(string)` | `[]` | no |
 | <a name="input_authorized-adder"></a> [authorized-adder](#input\_authorized-adder) | A member-style representation of the identity authorized to add new secret values (e.g. group:oncall@my-corp.dev). | `string` | n/a | yes |
 | <a name="input_create_placeholder_version"></a> [create\_placeholder\_version](#input\_create\_placeholder\_version) | Whether to create a placeholder secret version to avoid bad reference on first deploy. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name to give the secret. | `string` | n/a | yes |
 | <a name="input_notification-channels"></a> [notification-channels](#input\_notification-channels) | The channels to notify if the configuration data is improperly accessed. | `list(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
-| <a name="input_service-account"></a> [service-account](#input\_service-account) | The email of the service account that will access the secret. | `string` | n/a | yes |
+| <a name="input_service-account"></a> [service-account](#input\_service-account) | (Deprecated: Use service-accounts instead) The email of the service account that will access the secret. | `string` | `""` | no |
+| <a name="input_service-accounts"></a> [service-accounts](#input\_service-accounts) | The emails of the service accounts that will access the secret. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -22,7 +22,7 @@ resource "google_secret_manager_secret_version" "placeholder" {
 }
 
 locals {
-  accessors = [for sa in concat([var.service-account], var.additional-service-account-accessors) : "serviceAccount:${sa}"]
+  accessors = [for sa in concat([var.service-account], var.service-accounts) : "serviceAccount:${sa}"]
 }
 
 // Only the service account as which the service runs should have access to the secret.

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -13,14 +13,22 @@ variable "authorized-adder" {
 }
 
 variable "service-account" {
-  description = "The email of the service account that will access the secret."
+  description = "(Deprecated: Use service-accounts instead) The email of the service account that will access the secret."
   type        = string
+  default = ""
 }
 
-variable "additional-service-account-accessors" {
-  description = "Additional service accounts that will need to access the secret."
+variable "service-accounts" {
+  description = "The emails of the service accounts that will access the secret."
   type = list(string)
   default = []
+
+  validation {
+    # To support the legacy service-account variable, ensure that either that var is
+    # non-empty, or service-accounts is non-empty.
+    condition = var.service-account != "" || length(var.service-accounts) > 0
+    error_message = "Must provide at least one value in service-accounts"
+  }
 }
 
 variable "notification-channels" {


### PR DESCRIPTION
There are cases where more than one service is required to access a secret value (e.g. when using a redis module with auth, any viewers will also need access to the auth string to make the connection).

Retain the `_binding` resource in the secret module, but allow additional accessors to be defined.