### PR TITLE
Add service label to OTEL

### DIFF
--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -265,9 +265,10 @@ resource "google_cloud_run_v2_service" "this" {
       args = ["--config=env:OTEL_CONFIG"]
       env {
         name = "OTEL_CONFIG"
-        value = replace(replace(file("${path.module}/otel-config/config.yaml"),
+        value = replace(replace(replace(file("${path.module}/otel-config/config.yaml"),
           "REPLACE_ME_TEAM", var.squad),
-        "REPLACE_ME_PROJECT_ID", var.project_id)
+          "REPLACE_ME_PROJECT_ID", var.project_id),
+        "REPLACE_ME_SERVICE", var.name)
       }
 
       dynamic "resources" {

--- a/modules/regional-service/otel-config/config.yaml
+++ b/modules/regional-service/otel-config/config.yaml
@@ -26,6 +26,9 @@ processors:
       - action: insert
         key: team
         value: "REPLACE_ME_TEAM"
+      - action: insert
+        key: service
+        value: "REPLACE_ME_SERVICE"
 
   batch:
     # batch metrics before sending to reduce API usage


### PR DESCRIPTION
This should fix the issue where the `job` label isn't supported, by replacing it with `service`:

![image](https://github.com/user-attachments/assets/32ac4f85-c337-4768-9dff-896562f7434c)
