### PR TITLE
fix duplicate resource type error

### DIFF
--- a/modules/bucket-events/dashboard.tf
+++ b/modules/bucket-events/dashboard.tf
@@ -13,7 +13,7 @@ module "logs" {
 module "http" {
   source       = "../dashboard/sections/http"
   title        = "HTTP"
-  filter       = ["resource.type=\"cloud_run_revision\""]
+  filter       = []
   service_name = var.name
 }
 

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -72,7 +72,7 @@ module "logs" {
 module "http" {
   source       = "../dashboard/sections/http"
   title        = "HTTP"
-  filter       = ["resource.type=\"cloud_run_revision\""]
+  filter       = []
   service_name = var.name
 }
 

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -25,7 +25,7 @@ module "logs" {
 module "http" {
   source       = "../sections/http"
   title        = "HTTP"
-  filter       = ["resource.type=\"cloud_run_revision\""]
+  filter       = []
   service_name = var.service_name
 }
 

--- a/modules/dashboard/sections/http/main.tf
+++ b/modules/dashboard/sections/http/main.tf
@@ -21,7 +21,7 @@ module "failure_rate" {
 
   common_filter = concat(var.filter, [
     "metric.type=\"run.googleapis.com/request_count\"",
-    "resource.type=\"prometheus_target\"",
+    "resource.type=\"cloud_run_revision\"",
     "resource.label.\"service_name\"=\"${var.service_name}\"",
   ])
   numerator_additional_filter = ["metric.label.\"response_code_class\"=\"5xx\""]
@@ -30,7 +30,7 @@ module "failure_rate" {
 module "incoming_latency" {
   source = "../../widgets/latency"
   title  = "Incoming request latency"
-  filter = concat(var.filter, ["metric.type=\"run.googleapis.com/request_latencies\""])
+  filter = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/request_latencies\""])
 }
 
 locals {

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -14,7 +14,7 @@ module "logs" {
 module "http" {
   source       = "../sections/http"
   title        = "HTTP"
-  filter       = ["resource.type=\"cloud_run_revision\""]
+  filter       = []
   service_name = var.service_name
 }
 

--- a/modules/github-events/dashboard.tf
+++ b/modules/github-events/dashboard.tf
@@ -7,7 +7,7 @@ module "logs" {
 module "http" {
   source       = "../dashboard/sections/http"
   title        = "HTTP"
-  filter       = ["resource.type=\"cloud_run_revision\""]
+  filter       = []
   service_name = var.name
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -15,18 +15,18 @@ variable "authorized-adder" {
 variable "service-account" {
   description = "(Deprecated: Use service-accounts instead) The email of the service account that will access the secret."
   type        = string
-  default = ""
+  default     = ""
 }
 
 variable "service-accounts" {
   description = "The emails of the service accounts that will access the secret."
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 
   validation {
     # To support the legacy service-account variable, ensure that either that var is
     # non-empty, or service-accounts is non-empty.
-    condition = var.service-account != "" || length(var.service-accounts) > 0
+    condition     = var.service-account != "" || length(var.service-accounts) > 0
     error_message = "Must provide at least one value in service-accounts"
   }
 }


### PR DESCRIPTION
```
module.insights.module.services.module.image_scanning[0].module.scan-results-emits-events["grype"].module.recorder-dashboard.module.dashboard["scan-recorder-grype"].google_monitoring_dashboard.dashboard: Modifying... [id=projects/944165744297/dashboards/0e02722d-3b94-413a-93f1-5be4d3d7cdda]
  diagnostic_summary=
  | Error updating Dashboard "projects/944165744297/dashboards/bd78aa61-681d-481c-85e0-708666ff2bb0": googleapi: Error 400: Field mosaicLayout.tiles[19].widget.xyChart.dataSets[0].timeSeriesQuery.timeSeriesFilterRatio.numerator.filter has an invalid value: Field filter had an invalid value of "resource.type="cloud_run_revision"
  | metric.type="run.googleapis.com/request_count"
  | resource.type="prometheus_target"
  | resource.label."service_name"="scan-recorder-trivy"
  | metric.label."response_code_class"="5xx"": The 'resource.type' restriction is used more than once.
  | Field mosaicLayout.tiles[19].widget.xyChart.dataSets[0].timeSeriesQuery.timeSeriesFilterRatio.denominator.filter has an invalid value: Field filter had an invalid value of "resource.type="cloud_run_revision"
  | metric.type="run.googleapis.com/request_count"
  | resource.type="prometheus_target"
  | resource.label."service_name"="scan-recorder-trivy"": The 'resource.type' restriction is used more than once.
   tf_proto_version=5.8 tf_resource_type=google_monitoring_dashboard tf_rpc=ApplyResourceChange @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/diag/diagnostics.go:58
```