### PR TITLE
fix up dashboard filter

### DIFF
--- a/modules/bucket-events/dashboard.tf
+++ b/modules/bucket-events/dashboard.tf
@@ -20,7 +20,7 @@ module "http" {
 module "resources" {
   source        = "../dashboard/sections/resources"
   title         = "Resources"
-  filter        = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}\""]
+  filter        = []
   cloudrun_name = var.name
 
   notification_channels = var.notification_channels
@@ -47,11 +47,20 @@ module "dashboard" {
       "storage" : ""
       "eventing" : ""
     }
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = var.name
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -79,7 +79,7 @@ module "http" {
 module "resources" {
   source        = "../dashboard/sections/resources"
   title         = "Resources"
-  filter        = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}\""]
+  filter        = []
   cloudrun_name = var.name
 
   notification_channels = var.notification_channels
@@ -106,11 +106,20 @@ module "dashboard" {
       "service" : ""
       "eventing" : ""
     }
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = var.name
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -87,13 +87,13 @@ module "dashboard" {
       {
         # for GCP Cloud Run built-in metrics
         filterType  = "RESOURCE_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
       {
         # for Prometheus user added metrics
         filterType  = "METRIC_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
     ]

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -45,7 +45,7 @@ module "github" {
 module "resources" {
   source        = "../sections/resources"
   title         = "Resources"
-  filter        = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.service_name}\""]
+  filter        = []
   cloudrun_name = var.service_name
 
   notification_channels = var.notification_channels
@@ -83,11 +83,20 @@ module "dashboard" {
       "service" : ""
       "eventing" : ""
     }, var.labels)
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = each.key
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {
@@ -140,11 +149,20 @@ module "trigger-dashboards" {
       "service" : ""
       "eventing" : ""
     }, var.labels)
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = var.service_name
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -153,13 +153,13 @@ module "trigger-dashboards" {
       {
         # for GCP Cloud Run built-in metrics
         filterType  = "RESOURCE_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
       {
         # for Prometheus user added metrics
         filterType  = "METRIC_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
     ]

--- a/modules/dashboard/sections/gorm/gorm.tf
+++ b/modules/dashboard/sections/gorm/gorm.tf
@@ -9,7 +9,6 @@ module "total_request_count" {
   source = "../../widgets/xy"
   title  = "GORM total request count"
   filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_calls_total/counter\"",
   ])
@@ -24,7 +23,6 @@ module "request_errors" {
   source = "../../widgets/xy"
   title  = "GORM error request count"
   filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_calls_total/counter\"",
     "metric.label.\"code\"=monitoring.regex.full_match(\"Error.*\")",
@@ -41,7 +39,6 @@ module "table_request_count" {
   source = "../../widgets/xy"
   title  = "GORM table request count"
   filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_calls_total/counter\"",
   ])
@@ -59,7 +56,6 @@ module "error_rate" {
   legend = "Non-OK / All responses"
 
   common_filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_calls_total/counter\"",
   ])
@@ -70,7 +66,6 @@ module "op_request_count" {
   source = "../../widgets/xy"
   title  = "GORM op request count"
   filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_calls_total/counter\"",
   ])
@@ -86,7 +81,6 @@ module "open_connections" {
   source = "../../widgets/xy"
   title  = "GORM DB open connections"
   filter = concat(var.filter, [
-    "resource.label.\"job\"=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
     "metric.type=\"prometheus.googleapis.com/gorm_dbstats_open_connections/gauge\"",
   ])

--- a/modules/dashboard/sections/grpc/grpc.tf
+++ b/modules/dashboard/sections/grpc/grpc.tf
@@ -22,7 +22,6 @@ module "request_count" {
   filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.service_name}\"",
   ])
   group_by_fields = [
     "metric.label.\"grpc_service\"",
@@ -41,7 +40,6 @@ module "failure_rate" {
   common_filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/grpc_server_handled_total/counter\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.service_name}\"",
   ])
   numerator_additional_filter = [
     "metric.label.\"grpc_code\"!=monitoring.regex.full_match(\"${join("|", var.grpc_non_error_codes)}\")"
@@ -54,7 +52,6 @@ module "incoming_latency" {
   filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/grpc_server_handling_seconds/histogram\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.service_name}\"",
   ])
   group_by_fields = [
     "metric.label.\"grpc_service\"",
@@ -68,7 +65,6 @@ module "outbound_request_count" {
   filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/grpc_client_handled_total/counter\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.service_name}\"",
   ])
   group_by_fields = [
     "metric.label.\"grpc_service\"",
@@ -85,7 +81,6 @@ module "outbound_latency" {
   filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/grpc_client_handling_seconds/histogram\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.service_name}\"",
   ])
   group_by_fields = [
     "metric.label.\"grpc_service\"",

--- a/modules/dashboard/sections/http/main.tf
+++ b/modules/dashboard/sections/http/main.tf
@@ -22,7 +22,6 @@ module "failure_rate" {
   common_filter = concat(var.filter, [
     "metric.type=\"run.googleapis.com/request_count\"",
     "resource.type=\"cloud_run_revision\"",
-    "resource.label.\"service_name\"=\"${var.service_name}\"",
   ])
   numerator_additional_filter = ["metric.label.\"response_code_class\"=\"5xx\""]
 }
@@ -44,7 +43,6 @@ module "outbound_request_count" {
   title  = "Outbound Request count"
   filter = concat(local.gmp_filter, [
     "metric.type=\"prometheus.googleapis.com/http_client_request_count_total/counter\"",
-    "metric.label.service_name=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
   ])
   group_by_fields = [
@@ -60,7 +58,6 @@ module "outbound_request_latency" {
   title  = "Outbound request latency"
   filter = concat(local.gmp_filter, [
     "metric.type=\"prometheus.googleapis.com/http_client_request_duration_seconds/histogram\"",
-    "metric.label.service_name=\"${var.service_name}\"",
     "resource.type=\"prometheus_target\"",
   ])
 }

--- a/modules/dashboard/sections/resources/main.tf
+++ b/modules/dashboard/sections/resources/main.tf
@@ -11,7 +11,7 @@ module "width" { source = "../width" }
 module "instance_count" {
   source          = "../../widgets/xy"
   title           = "Instance count + revisions"
-  filter          = concat(var.filter, ["metric.type=\"run.googleapis.com/container/instance_count\""])
+  filter          = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/instance_count\""])
   group_by_fields = ["resource.label.\"revision_name\""]
   primary_align   = "ALIGN_MEAN"
   primary_reduce  = "REDUCE_SUM"
@@ -21,7 +21,7 @@ module "instance_count" {
 module "cpu_utilization" {
   source         = "../../widgets/xy"
   title          = "CPU utilization"
-  filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/cpu/utilizations\""])
+  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/cpu/utilizations\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
 }
@@ -41,7 +41,7 @@ module "disk_usage" {
 module "memory_utilization" {
   source         = "../../widgets/xy"
   title          = "Memory utilization"
-  filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/memory/utilizations\""])
+  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/memory/utilizations\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
 }
@@ -49,7 +49,7 @@ module "memory_utilization" {
 module "startup_latency" {
   source         = "../../widgets/xy"
   title          = "Startup latency"
-  filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/startup_latencies\""])
+  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/startup_latencies\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
   plot_type      = "STACKED_BAR"
@@ -58,7 +58,7 @@ module "startup_latency" {
 module "sent_bytes" {
   source         = "../../widgets/xy"
   title          = "Sent bytes"
-  filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/network/sent_bytes_count\""])
+  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/network/sent_bytes_count\""])
   primary_align  = "ALIGN_MEAN"
   primary_reduce = "REDUCE_NONE"
 }
@@ -66,7 +66,7 @@ module "sent_bytes" {
 module "received_bytes" {
   source         = "../../widgets/xy"
   title          = "Received bytes"
-  filter         = concat(var.filter, ["metric.type=\"run.googleapis.com/container/network/received_bytes_count\""])
+  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/network/received_bytes_count\""])
   primary_align  = "ALIGN_MEAN"
   primary_reduce = "REDUCE_NONE"
 }

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -84,13 +84,13 @@ module "dashboard" {
       {
         # for GCP Cloud Run built-in metrics
         filterType  = "RESOURCE_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
       {
         # for Prometheus user added metrics
         filterType  = "METRIC_LABEL"
-        stringValue = var.name
+        stringValue = var.service_name
         labelKey    = "service_name"
       },
     ]

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -41,7 +41,7 @@ module "gorm" {
 module "resources" {
   source                = "../sections/resources"
   title                 = "Resources"
-  filter                = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.service_name}\""]
+  filter                = []
   cloudrun_name         = var.service_name
   notification_channels = var.notification_channels
 }
@@ -80,11 +80,20 @@ module "dashboard" {
     labels = merge({
       "service" : ""
     }, var.labels)
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = var.service_name
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {

--- a/modules/github-events/dashboard.tf
+++ b/modules/github-events/dashboard.tf
@@ -14,7 +14,7 @@ module "http" {
 module "resources" {
   source        = "../dashboard/sections/resources"
   title         = "Resources"
-  filter        = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}\""]
+  filter        = []
   cloudrun_name = var.name
 
   notification_channels = var.notification_channels
@@ -40,11 +40,20 @@ module "dashboard" {
       "github" : ""
       "eventing" : ""
     }
-    dashboardFilters = [{
-      filterType  = "RESOURCE_LABEL"
-      stringValue = var.name
-      labelKey    = "service_name"
-    }]
+    dashboardFilters = [
+      {
+        # for GCP Cloud Run built-in metrics
+        filterType  = "RESOURCE_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+      {
+        # for Prometheus user added metrics
+        filterType  = "METRIC_LABEL"
+        stringValue = var.name
+        labelKey    = "service_name"
+      },
+    ]
 
     // https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#mosaiclayout
     mosaicLayout = {

--- a/modules/regional-service/otel-config/config.yaml
+++ b/modules/regional-service/otel-config/config.yaml
@@ -27,7 +27,7 @@ processors:
         key: team
         value: "REPLACE_ME_TEAM"
       - action: insert
-        key: service
+        key: service_name
         value: "REPLACE_ME_SERVICE"
 
   batch:


### PR DESCRIPTION
previous dashboard relied on the `RESOURCE_LABEL` `service_name` metric, which is only available for built in google cloud run metrics.

to have it work for our custom prometheus metric, we add `METRIC_LABEL` `service_name`
now that we insert a metric `service_name` label for all cloud run services.
we can now leverage the dashboard filter to select the service rather than needing to specify it for each widget

as sections end up having a mix of build-in and custom prometheus metrics, module level filter with `resource.type=cloud_run_revision` no longer apply
add the resource type to each widget and remove the one at the module level


address issue where it dashboard does not filter on service
https://chainguard-dev.slack.com/archives/C083P5AQNQ2/p1750171310685599