### PR TITLE
Give the bot permissions to `autofix`

### DIFF
--- a/.github/chainguard/ghreconciler.sts.yaml
+++ b/.github/chainguard/ghreconciler.sts.yaml
@@ -4,6 +4,6 @@ subject: "117292703478108941530"
 
 permissions:
   checks: read
-  contents: read
+  contents: write
   pull_requests: write
   statuses: read


### PR DESCRIPTION
This is needed for `mattmoor:autofix` to work (TBD whether this is sufficient for writing to forks, but that'll be some of the fun of debugging this!)