### PR TITLE
Truncate WIF provider pool display name

### DIFF
--- a/modules/github-wif-provider/main.tf
+++ b/modules/github-wif-provider/main.tf
@@ -2,7 +2,11 @@ resource "google_iam_workload_identity_pool" "this" {
   project                   = var.project_id
   provider                  = google-beta
   workload_identity_pool_id = var.name
-  display_name              = "Pool for ${var.name}"
+
+  // Maximum display_name length is 32 characters. 32 - len("Pool for") = 23.
+  // https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool#display_name-1
+  display_name = "Pool for ${substr(var.name, 0, min(23, length(var.name)))}"
+  description  = "Pool for ${var.name}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "this" {


### PR DESCRIPTION
Sometimes people want to pass in longer names.

This has come up in some internal PRs:

- https://github.com/chainguard-dev/infra/pull/433
- https://github.com/chainguard-dev/infra/pull/436
- https://github.com/chainguard-dev/infra/pull/712

I think another good approach would be to validate the `name` variable,
restricting it to 23 characters, and to provide a further `description` variable so that users can provide the full name without truncation.
