### PR TITLE
clog: ensure gcp logging is enabled

### DIFF
--- a/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
+++ b/modules/cloudevent-recorder/cmd/dejavu-bq/main.go
@@ -13,6 +13,7 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/chainguard-dev/clog"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/sethvargo/go-envconfig"

--- a/modules/workqueue/cmd/dispatcher/main.go
+++ b/modules/workqueue/cmd/dispatcher/main.go
@@ -17,6 +17,7 @@ import (
 	"chainguard.dev/go-grpc-kit/pkg/options"
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/clog"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	"github.com/sethvargo/go-envconfig"
 	"golang.org/x/net/http2"

--- a/modules/workqueue/cmd/inmem/main.go
+++ b/modules/workqueue/cmd/inmem/main.go
@@ -14,6 +14,7 @@ import (
 
 	"chainguard.dev/go-grpc-kit/pkg/duplex"
 	"github.com/chainguard-dev/clog"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	"github.com/sethvargo/go-envconfig"
 	"golang.org/x/sync/errgroup"

--- a/modules/workqueue/cmd/receiver/main.go
+++ b/modules/workqueue/cmd/receiver/main.go
@@ -15,6 +15,7 @@ import (
 	"chainguard.dev/go-grpc-kit/pkg/options"
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/clog"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	"github.com/chainguard-dev/terraform-infra-common/pkg/httpmetrics"
 	"github.com/sethvargo/go-envconfig"
 	"google.golang.org/grpc"

--- a/modules/workqueue/cmd/send/main.go
+++ b/modules/workqueue/cmd/send/main.go
@@ -17,6 +17,7 @@ import (
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
 	"github.com/chainguard-dev/clog"
+	_ "github.com/chainguard-dev/clog/gcp/init"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 


### PR DESCRIPTION
I noticed a few common services weren't optimizing their logs for GCP, which meant they were missing some details (trace ID, source location, correct severity)

This fixes that, anywhere I could find a `cmd/main.go` that looked like a service without the import.