### PR TITLE
avoid specifying resource type as module input filter

### DIFF
--- a/modules/bucket-events/dashboard.tf
+++ b/modules/bucket-events/dashboard.tf
@@ -5,9 +5,10 @@ module "topic" {
 }
 
 module "logs" {
-  source = "../dashboard/sections/logs"
-  title  = "Service Logs"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source        = "../dashboard/sections/logs"
+  title         = "Service Logs"
+  filter        = []
+  cloudrun_type = "service"
 }
 
 module "http" {
@@ -22,6 +23,7 @@ module "resources" {
   title         = "Resources"
   filter        = []
   cloudrun_name = var.name
+  cloudrun_type = "service"
 
   notification_channels = var.notification_channels
 }

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -64,9 +64,10 @@ module "topic" {
 }
 
 module "logs" {
-  source = "../dashboard/sections/logs"
-  title  = "Service Logs"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source        = "../dashboard/sections/logs"
+  title         = "Service Logs"
+  filter        = []
+  cloudrun_type = "service"
 }
 
 module "http" {
@@ -81,6 +82,7 @@ module "resources" {
   title         = "Resources"
   filter        = []
   cloudrun_name = var.name
+  cloudrun_type = "service"
 
   notification_channels = var.notification_channels
 }

--- a/modules/dashboard/cloudevent-receiver/dashboard.tf
+++ b/modules/dashboard/cloudevent-receiver/dashboard.tf
@@ -17,9 +17,10 @@ module "errgrp" {
 }
 
 module "logs" {
-  source = "../sections/logs"
-  title  = "Service Logs"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source        = "../sections/logs"
+  title         = "Service Logs"
+  filter        = []
+  cloudrun_type = "service"
 }
 
 module "http" {
@@ -47,6 +48,7 @@ module "resources" {
   title         = "Resources"
   filter        = []
   cloudrun_name = var.service_name
+  cloudrun_type = "service"
 
   notification_channels = var.notification_channels
 }

--- a/modules/dashboard/job/dashboard.tf
+++ b/modules/dashboard/job/dashboard.tf
@@ -11,16 +11,18 @@ module "errgrp" {
 }
 
 module "logs" {
-  source = "../sections/logs"
-  title  = "Job Logs"
-  filter = ["resource.type=\"cloud_run_job\"", "resource.labels.job_name=\"${local.job_name}\""]
+  source        = "../sections/logs"
+  title         = "Job Logs"
+  filter        = []
+  cloudrun_type = "job"
 }
 
 module "resources" {
   source                = "../sections/resources"
   title                 = "Resources"
-  filter                = ["resource.type=\"cloud_run_job\"", "resource.labels.job_name=\"${local.job_name}\""]
+  filter                = []
   cloudrun_name         = local.job_name
+  cloudrun_type         = "job"
   notification_channels = var.notification_channels
 }
 

--- a/modules/dashboard/sections/logs/README.md
+++ b/modules/dashboard/sections/logs/README.md
@@ -23,6 +23,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudrun_type"></a> [cloudrun\_type](#input\_cloudrun\_type) | n/a | `string` | `"service"` | no |
 | <a name="input_collapsed"></a> [collapsed](#input\_collapsed) | n/a | `bool` | `true` | no |
 | <a name="input_filter"></a> [filter](#input\_filter) | n/a | `list(string)` | n/a | yes |
 | <a name="input_title"></a> [title](#input\_title) | n/a | `string` | n/a | yes |

--- a/modules/dashboard/sections/logs/main.tf
+++ b/modules/dashboard/sections/logs/main.tf
@@ -1,13 +1,25 @@
 variable "title" { type = string }
 variable "filter" { type = list(string) }
 variable "collapsed" { default = true }
-
 module "width" { source = "../width" }
+variable "cloudrun_type" {
+  type    = string
+  default = "service"
+
+  validation {
+    condition     = contains(["service", "job"], var.cloudrun_type)
+    error_message = "Allowed values for 'cloudrun_type' are 'service' or 'job'."
+  }
+}
+
+locals {
+  filter = concat(var.filter, var.cloudrun_type == "job" ? ["resource.type=\"cloud_run_job\""] : ["resource.type=\"cloud_run_revision\""])
+}
 
 module "logs" {
   source = "../../widgets/logs"
   title  = var.title
-  filter = var.filter
+  filter = local.filter
 }
 
 locals {

--- a/modules/dashboard/sections/resources/README.md
+++ b/modules/dashboard/sections/resources/README.md
@@ -30,6 +30,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudrun_name"></a> [cloudrun\_name](#input\_cloudrun\_name) | n/a | `string` | n/a | yes |
+| <a name="input_cloudrun_type"></a> [cloudrun\_type](#input\_cloudrun\_type) | n/a | `string` | `"service"` | no |
 | <a name="input_collapsed"></a> [collapsed](#input\_collapsed) | n/a | `bool` | `false` | no |
 | <a name="input_filter"></a> [filter](#input\_filter) | n/a | `list(string)` | n/a | yes |
 | <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | n/a | `list(string)` | n/a | yes |

--- a/modules/dashboard/sections/resources/main.tf
+++ b/modules/dashboard/sections/resources/main.tf
@@ -1,9 +1,22 @@
 variable "title" { type = string }
 variable "filter" { type = list(string) }
 variable "cloudrun_name" { type = string }
+variable "cloudrun_type" {
+  type    = string
+  default = "service"
+
+  validation {
+    condition     = contains(["service", "job"], var.cloudrun_type)
+    error_message = "Allowed values for 'cloudrun_type' are 'service' or 'job'."
+  }
+}
 variable "collapsed" { default = false }
 variable "notification_channels" {
   type = list(string)
+}
+
+locals {
+  filter = concat(var.filter, var.cloudrun_type == "job" ? ["resource.type=\"cloud_run_job\""] : ["resource.type=\"cloud_run_revision\""])
 }
 
 module "width" { source = "../width" }
@@ -11,7 +24,7 @@ module "width" { source = "../width" }
 module "instance_count" {
   source          = "../../widgets/xy"
   title           = "Instance count + revisions"
-  filter          = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/instance_count\""])
+  filter          = concat(local.filter, ["metric.type=\"run.googleapis.com/container/instance_count\""])
   group_by_fields = ["resource.label.\"revision_name\""]
   primary_align   = "ALIGN_MEAN"
   primary_reduce  = "REDUCE_SUM"
@@ -21,7 +34,7 @@ module "instance_count" {
 module "cpu_utilization" {
   source         = "../../widgets/xy"
   title          = "CPU utilization"
-  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/cpu/utilizations\""])
+  filter         = concat(local.filter, ["metric.type=\"run.googleapis.com/container/cpu/utilizations\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
 }
@@ -29,10 +42,9 @@ module "cpu_utilization" {
 module "disk_usage" {
   source = "../../widgets/xy"
   title  = "Disk usage"
-  filter = concat([
+  filter = concat(var.filter, [
     "metric.type=\"prometheus.googleapis.com/disk_usage_bytes/gauge\"",
     "resource.type=\"prometheus_target\"",
-    "resource.label.\"job\"=\"${var.cloudrun_name}\"",
   ])
   primary_align  = "ALIGN_MEAN"
   primary_reduce = "REDUCE_PERCENTILE_99"
@@ -41,7 +53,7 @@ module "disk_usage" {
 module "memory_utilization" {
   source         = "../../widgets/xy"
   title          = "Memory utilization"
-  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/memory/utilizations\""])
+  filter         = concat(local.filter, ["metric.type=\"run.googleapis.com/container/memory/utilizations\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
 }
@@ -49,7 +61,7 @@ module "memory_utilization" {
 module "startup_latency" {
   source         = "../../widgets/xy"
   title          = "Startup latency"
-  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/startup_latencies\""])
+  filter         = concat(local.filter, ["metric.type=\"run.googleapis.com/container/startup_latencies\""])
   primary_align  = "ALIGN_DELTA"
   primary_reduce = "REDUCE_PERCENTILE_99"
   plot_type      = "STACKED_BAR"
@@ -58,7 +70,7 @@ module "startup_latency" {
 module "sent_bytes" {
   source         = "../../widgets/xy"
   title          = "Sent bytes"
-  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/network/sent_bytes_count\""])
+  filter         = concat(local.filter, ["metric.type=\"run.googleapis.com/container/network/sent_bytes_count\""])
   primary_align  = "ALIGN_MEAN"
   primary_reduce = "REDUCE_NONE"
 }
@@ -66,7 +78,7 @@ module "sent_bytes" {
 module "received_bytes" {
   source         = "../../widgets/xy"
   title          = "Received bytes"
-  filter         = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/container/network/received_bytes_count\""])
+  filter         = concat(local.filter, ["metric.type=\"run.googleapis.com/container/network/received_bytes_count\""])
   primary_align  = "ALIGN_MEAN"
   primary_reduce = "REDUCE_NONE"
 }

--- a/modules/dashboard/service/dashboard.tf
+++ b/modules/dashboard/service/dashboard.tf
@@ -6,9 +6,10 @@ module "errgrp" {
 }
 
 module "logs" {
-  source = "../sections/logs"
-  title  = "Service Logs"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source        = "../sections/logs"
+  title         = "Service Logs"
+  filter        = []
+  cloudrun_type = "service"
 }
 
 module "http" {
@@ -43,6 +44,7 @@ module "resources" {
   title                 = "Resources"
   filter                = []
   cloudrun_name         = var.service_name
+  cloudrun_type         = "service"
   notification_channels = var.notification_channels
 }
 

--- a/modules/github-events/dashboard.tf
+++ b/modules/github-events/dashboard.tf
@@ -1,7 +1,8 @@
 module "logs" {
-  source = "../dashboard/sections/logs"
-  title  = "Service Logs"
-  filter = ["resource.type=\"cloud_run_revision\""]
+  source        = "../dashboard/sections/logs"
+  title         = "Service Logs"
+  filter        = []
+  cloudrun_type = "service"
 }
 
 module "http" {
@@ -16,6 +17,7 @@ module "resources" {
   title         = "Resources"
   filter        = []
   cloudrun_name = var.name
+  cloudrun_type = "service"
 
   notification_channels = var.notification_channels
 }

--- a/modules/workqueue/dashboard.tf
+++ b/modules/workqueue/dashboard.tf
@@ -1,15 +1,17 @@
 module "width" { source = "../dashboard/sections/width" }
 
 module "receiver-logs" {
-  source = "../dashboard/sections/logs"
-  title  = "Receiver Logs"
-  filter = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}-rcv\""]
+  source        = "../dashboard/sections/logs"
+  title         = "Receiver Logs"
+  filter        = ["resource.labels.service_name=\"${var.name}-rcv\""]
+  cloudrun_type = "service"
 }
 
 module "dispatcher-logs" {
-  source = "../dashboard/sections/logs"
-  title  = "Dispatcher Logs"
-  filter = ["resource.type=\"cloud_run_revision\"", "resource.labels.service_name=\"${var.name}-dsp\""]
+  source        = "../dashboard/sections/logs"
+  title         = "Dispatcher Logs"
+  filter        = ["resource.labels.service_name=\"${var.name}-dsp\""]
+  cloudrun_type = "service"
 }
 
 module "max-attempts" {


### PR DESCRIPTION
simplify input for logs/resources so users dont need to know the global resource_type filter to apply, 
as it frequently does not apply to all widgets

