### PR TITLE
Standard convention for labeling by module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,30 @@ provider "google" {
   project = var.project
 }
 ```
+
+## Resource Labeling Convention
+
+All modules in this repository follow a consistent labeling pattern for GCP cost allocation and resource organization:
+
+```hcl
+locals {
+  default_labels = {
+    basename(abspath(path.module)) = var.name
+  }
+
+  squad_label = var.squad != "" ? {
+    squad = var.squad
+    team  = var.squad
+  } : {}
+
+  merged_labels = merge(local.default_labels, local.squad_label, var.labels)
+}
+```
+
+This pattern:
+- **Enables cost tracking** to break down each module by use
+- **Maintains consistency** across all infrastructure modules
+- **Supports team attribution** through squad/team labels
+- **Allows custom labels** via the `labels` variable
+
+The `basename(abspath(path.module))` automatically derives the module name (e.g., "gke", "redis", "workqueue") without requiring hardcoded values.

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -17,7 +17,7 @@ locals {
 
   // Labels
   default_labels = {
-    bastion = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = {

--- a/modules/bucket-events/main.tf
+++ b/modules/bucket-events/main.tf
@@ -9,7 +9,7 @@ locals {
   }, local.lowercase, local.lowercase)
 
   default_labels = {
-    "bucket-events" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudevent-broker/main.tf
+++ b/modules/cloudevent-broker/main.tf
@@ -7,7 +7,7 @@ terraform {
 
 locals {
   default_labels = {
-    "cloudevent-broker" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudevent-recorder/main.tf
+++ b/modules/cloudevent-recorder/main.tf
@@ -22,7 +22,7 @@ locals {
   ]...)
 
   default_labels = {
-    "cloudevent-recorder" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 locals {
   default_labels = {
-    cloudsql = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/configmap/main.tf
+++ b/modules/configmap/main.tf
@@ -1,6 +1,6 @@
 locals {
   default_labels = {
-    "configmap" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/gke-ap/main.tf
+++ b/modules/gke-ap/main.tf
@@ -34,7 +34,7 @@ resource "google_project_iam_member" "cluster" {
 
 locals {
   default_labels = {
-    "gke" : var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = {

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -41,7 +41,7 @@ resource "google_service_account_iam_member" "terraform_gke_impersonation" {
 
 locals {
   default_labels = {
-    "gke" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = {

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -25,7 +25,7 @@ terraform {
 
 locals {
   default_labels = {
-    "redis" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -29,7 +29,7 @@ locals {
   }
 
   default_labels = {
-    "regional-service" : var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = {

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -27,7 +27,7 @@ locals {
   accessor_emails = [for sa in concat([var.service-account], var.service-accounts) : sa if sa != ""]
 
   default_labels = {
-    "secret" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/workqueue/main.tf
+++ b/modules/workqueue/main.tf
@@ -2,7 +2,7 @@ locals {
   sa_prefix = "${var.name}-"
 
   default_labels = {
-    "workqueue" = var.name
+    basename(abspath(path.module)) = var.name
   }
 
   squad_label = var.squad != "" ? {


### PR DESCRIPTION
- Follows up from https://github.com/chainguard-dev/terraform-infra-common/pull/913
- Pattern originally introduced in #511

Per feedback in https://github.com/chainguard-dev/terraform-infra-common/pull/913#discussion_r2167352412

I've added documentation as well.

If we think these labels aren't actively used, I'm also happy to remove them. 

If we want to go further into module-based labelling, then it would probably be useful to have a `module: <module-name>` label as well, rather than one where `<module-name>` is the key. 