### PR TITLE
Add `terraform-module` label to all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All modules in this repository follow a consistent labeling pattern for GCP cost
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {
@@ -42,5 +43,6 @@ This pattern:
 - **Maintains consistency** across all infrastructure modules
 - **Supports team attribution** through squad/team labels
 - **Allows custom labels** via the `labels` variable
+- **Provides module identification** via the `terraform-module` label
 
 The `basename(abspath(path.module))` automatically derives the module name (e.g., "gke", "redis", "workqueue") without requiring hardcoded values.

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -18,6 +18,7 @@ locals {
   // Labels
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = {

--- a/modules/bucket-events/main.tf
+++ b/modules/bucket-events/main.tf
@@ -10,6 +10,7 @@ locals {
 
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudevent-broker/main.tf
+++ b/modules/cloudevent-broker/main.tf
@@ -8,6 +8,7 @@ terraform {
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudevent-recorder/main.tf
+++ b/modules/cloudevent-recorder/main.tf
@@ -23,6 +23,7 @@ locals {
 
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -11,6 +11,7 @@ terraform {
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/configmap/main.tf
+++ b/modules/configmap/main.tf
@@ -1,6 +1,7 @@
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/gke-ap/main.tf
+++ b/modules/gke-ap/main.tf
@@ -35,6 +35,7 @@ resource "google_project_iam_member" "cluster" {
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = {

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -42,6 +42,7 @@ resource "google_service_account_iam_member" "terraform_gke_impersonation" {
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = {

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -26,6 +26,7 @@ terraform {
 locals {
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -30,6 +30,7 @@ locals {
 
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = {

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -28,6 +28,7 @@ locals {
 
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {

--- a/modules/workqueue/main.tf
+++ b/modules/workqueue/main.tf
@@ -3,6 +3,7 @@ locals {
 
   default_labels = {
     basename(abspath(path.module)) = var.name
+    terraform-module               = basename(abspath(path.module))
   }
 
   squad_label = var.squad != "" ? {


### PR DESCRIPTION
Gives us better insight into which resources belong to which modules.

Follows up from https://github.com/chainguard-dev/terraform-infra-common/pull/923