### PR TITLE
ignore method `GetSecretVersion` in the abnormal secret access alert for authorized accessors

### DIFF
--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -90,7 +90,7 @@ resource "google_monitoring_alert_policy" "anomalous-secret-access" {
       -- Ignore the identity that is intended to access this.
       -(
         protoPayload.authenticationInfo.principalEmail=~"${join("|", local.accessor_emails)}"
-        protoPayload.methodName="google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion"
+        protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.(AccessSecretVersion|GetSecretVersion)"
       )
       EOT
 


### PR DESCRIPTION
The use of the `redis` module is causing the `Abnormal Secret Access` alert to fire for `GetSecretVersion`, possibly due to the usage of the `google_secret_manager_secret_version` resource. This is a valid action for an authorized accessor, so ignore this method for the alert.