### PR TITLE
dashboard: Adjust aggregation of high cardinality widgets

### DIFF
--- a/modules/dashboard/sections/grpc/grpc.tf
+++ b/modules/dashboard/sections/grpc/grpc.tf
@@ -29,7 +29,7 @@ module "request_count" {
     "metric.label.\"grpc_code\""
   ]
   primary_align  = "ALIGN_RATE"
-  primary_reduce = "REDUCE_NONE"
+  primary_reduce = "REDUCE_SUM"
 }
 
 module "failure_rate" {
@@ -72,7 +72,7 @@ module "outbound_request_count" {
     "metric.label.\"grpc_code\""
   ]
   primary_align  = "ALIGN_RATE"
-  primary_reduce = "REDUCE_NONE"
+  primary_reduce = "REDUCE_SUM"
 }
 
 module "outbound_latency" {

--- a/modules/dashboard/sections/http/main.tf
+++ b/modules/dashboard/sections/http/main.tf
@@ -11,7 +11,7 @@ module "request_count" {
   filter          = concat(var.filter, ["metric.type=\"run.googleapis.com/request_count\""])
   group_by_fields = ["metric.label.\"response_code_class\""]
   primary_align   = "ALIGN_RATE"
-  primary_reduce  = "REDUCE_NONE"
+  primary_reduce  = "REDUCE_SUM"
 }
 
 module "failure_rate" {
@@ -50,7 +50,7 @@ module "outbound_request_count" {
     "metric.label.\"host\"",
   ]
   primary_align  = "ALIGN_RATE"
-  primary_reduce = "REDUCE_NONE"
+  primary_reduce = "REDUCE_SUM"
 }
 
 module "outbound_request_latency" {
@@ -60,6 +60,9 @@ module "outbound_request_latency" {
     "metric.type=\"prometheus.googleapis.com/http_client_request_duration_seconds/histogram\"",
     "resource.type=\"prometheus_target\"",
   ])
+  group_by_fields = [
+    "metric.label.\"host\"",
+  ]
 }
 
 locals {


### PR DESCRIPTION
This adjusts the aggregation of some of our widgets to be more useful out of the box. In particular:
- (Outbound) Request Count now doesn't show the respective counts per instance of the service but instead aggregates the sum overall.
- Outbound Request Latency of HTTP requests is broken down per host to be able to see issues calling a specific dependencies. This also matches the gRPC behavior more closely.