### PR TITLE
Fix on_host_maintenance

### DIFF
--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -137,8 +137,7 @@ resource "google_compute_instance" "bastion" {
   allow_stopping_for_update = true
 
   scheduling {
-    automatic_restart   = true
-    on_host_maintenance = "TERMINATE"
+    automatic_restart = true
   }
 
   deletion_protection = var.deletion_protection


### PR DESCRIPTION
Hit this error when trying to deploy a bastion after `on_host_maintenance = "TERMINATE"` was added.

```
module.bastion.google_compute_instance.bastion: Creating...
Error: -07T14:33:55.068Z [ERROR] provider.terraform-provider-google_v6.40.0_x5: Response contains error diagnostic: @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/diag/diagnostics.go:58 @module=sdk.proto diagnostic_detail="" tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/google tf_req_id=b2af8385-cf11-22b6-e2cd-dfb2036f4887 tf_resource_type=google_compute_instance tf_rpc=ApplyResourceChange diagnostic_severity=ERROR diagnostic_summary="Error creating instance: googleapi: Error 400: e2 instances do not support onHostMaintenance=TERMINATE unless they are preemptible., badRequest" timestamp=2025-07-07T14:33:55.068Z
Error: -07T14:33:55.069Z [ERROR] vertex "module.bastion.google_compute_instance.bastion" error: Error creating instance: googleapi: Error 400: e2 instances do not support onHostMaintenance=TERMINATE unless they are preemptible., badRequest
╷
│ Error: Error creating instance: googleapi: Error 400: e2 instances do not support onHostMaintenance=TERMINATE unless they are preemptible., badRequest
```

Looking at the docs, either you must use `on_host_maintenance = "MIGRATE"` or set `preemptible = true` and change `automatic_restart` to `false`.