### PR TITLE
Add dynamic block for advanced_datapath_observability_config to GKE module

### DIFF
--- a/modules/gke/README.md
+++ b/modules/gke/README.md
@@ -29,6 +29,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_advanced_datapath_observability_config"></a> [advanced\_datapath\_observability\_config](#input\_advanced\_datapath\_observability\_config) | Config for Advanced Datapath Monitoring. | <pre>object({<br/>    enable         = optional(bool, false)<br/>    enable_metrics = optional(bool, true)<br/>    enable_relay   = optional(bool, true)<br/>  })</pre> | `{}` | no |
 | <a name="input_cluster_autoscaling"></a> [cluster\_autoscaling](#input\_cluster\_autoscaling) | Enabling of node auto-provisioning | `bool` | `false` | no |
 | <a name="input_cluster_autoscaling_cpu_limits"></a> [cluster\_autoscaling\_cpu\_limits](#input\_cluster\_autoscaling\_cpu\_limits) | Cluster autoscaling cpu limits | <pre>object({<br/>    resource_type = optional(string, "cpu")<br/>    minimum       = optional(number, 4)<br/>    maximum       = optional(number, 10)<br/>  })</pre> | `{}` | no |
 | <a name="input_cluster_autoscaling_memory_limits"></a> [cluster\_autoscaling\_memory\_limits](#input\_cluster\_autoscaling\_memory\_limits) | Cluster autoscaling memory limits | <pre>object({<br/>    resource_type = optional(string, "memory"),<br/>    minimum       = optional(number, 8)<br/>    maximum       = optional(number, 80)<br/>  })</pre> | `null` | no |

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -187,6 +187,14 @@ resource "google_container_cluster" "this" {
     enable_components = ["SYSTEM_COMPONENTS", "APISERVER", "SCHEDULER", "CONTROLLER_MANAGER", "STORAGE", "POD"]
     managed_prometheus { enabled = true }
 
+    dynamic "advanced_datapath_observability_config" {
+      for_each = var.advanced_datapath_observability_config.enable ? ["placeholder"] : []
+
+      content {
+        enable_metrics = var.advanced_datapath_observability_config.enable_metrics
+        enable_relay   = var.advanced_datapath_observability_config.enable_relay
+      }
+    }
   }
 
   # This can't hurt... right?

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -161,6 +161,16 @@ variable "resource_usage_export_config" {
   default = {}
 }
 
+variable "advanced_datapath_observability_config" {
+  description = "Config for Advanced Datapath Monitoring."
+  type = object({
+    enable         = optional(bool, false)
+    enable_metrics = optional(bool, true)
+    enable_relay   = optional(bool, true)
+  })
+  default = {}
+}
+
 variable "service_account_impersonation_email" {
   type        = string
   default     = null


### PR DESCRIPTION
This PR adds opt-in datapath observability (for Dataplane v2) to the GKE module.

More info can be found in the GKE docs [here](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-dpv2-observability#standard-cluster-with-metrics-enabled).