### PR TITLE
Add in DNS logging

### DIFF
--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -61,6 +61,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | n/a | `string` | `"10.0.0.0/8"` | no |
+| <a name="input_hosted_zone_logging_enabled"></a> [hosted\_zone\_logging\_enabled](#input\_hosted\_zone\_logging\_enabled) | Whether or not to enable DNS Hosted Zone Cloud Logging | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the networking resources. | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_netnum_offset"></a> [netnum\_offset](#input\_netnum\_offset) | cidrsubnet netnum offset for the subnet. See https://developer.hashicorp.com/terraform/language/functions/cidrsubnet for more details | `number` | `0` | no |

--- a/modules/networking/dns.tf
+++ b/modules/networking/dns.tf
@@ -21,6 +21,10 @@ resource "google_dns_managed_zone" "cloud-run-internal" {
       network_url = google_compute_network.this.id
     }
   }
+
+  cloud_logging_config {
+    enable_logging = var.hosted_zone_logging_enabled
+  }
 }
 
 // Create a record for *.run.app that points to private.googleapis.com
@@ -50,6 +54,10 @@ resource "google_dns_managed_zone" "private-google-apis" {
     networks {
       network_url = google_compute_network.this.id
     }
+  }
+
+  cloud_logging_config {
+    enable_logging = var.hosted_zone_logging_enabled
   }
 }
 

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -53,3 +53,9 @@ variable "product" {
   type        = string
   default     = "unknown"
 }
+
+variable "hosted_zone_logging_enabled" {
+  description = "Whether or not to enable DNS Hosted Zone Cloud Logging"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
https://github.com/chainguard-dev/infosec/issues/622

I created a new variable for this, `hosted_zone_logging_enabled`, that defaults to `true`. Consumers can easily disable this logging by setting the variable to `false`.