### PR TITLE
workqueue: Implement logging interface for gRPC request handler

### DIFF
--- a/pkg/workqueue/log.go
+++ b/pkg/workqueue/log.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package workqueue
+
+import (
+	"log/slog"
+	"time"
+)
+
+// LogAttrs returns a slice of attributes for logging purposes.
+func (x *ProcessRequest) LogAttrs() []any {
+	return []any{
+		slog.String("key", x.Key),
+		slog.Int64("priority", x.Priority),
+		slog.Duration("delay", time.Duration(x.DelaySeconds)*time.Second),
+	}
+}


### PR DESCRIPTION
This implements the interface introduced in https://github.com/chainguard-dev/mono/blob/c41a30a7146aad0fdd12a4897b6da9267f180c74/api-internal/pkg/interceptors/requests.go#L22-L24.

This will not automatically cause these to be added to logs. Only in services that actually use the request handlers (which currently is only catalog-syncer) will call this.