### PR TITLE
Redo "other" host bucketing log throttling with atomics

### DIFF
--- a/pkg/httpmetrics/transport.go
+++ b/pkg/httpmetrics/transport.go
@@ -194,12 +194,13 @@ func bucketize(ctx context.Context, host string) string {
 		}
 	}
 
+	// Only log every 10th request to avoid flooding the logs.
 	v, _ := seenHostMap.LoadOrStore(host, &atomic.Int64{})
 	vInt := v.(*atomic.Int64)
-
 	if seen := vInt.Add(1); (seen-1)%10 == 0 {
 		clog.WarnContext(ctx, `bucketing host as "other", use httpmetrics.SetBucket{Suffixe}s`, "host", host, "seen", seen)
 	}
+
 	return "other"
 }
 


### PR DESCRIPTION
The current method is racy and make me question why we're not seeing the respective log in prod, so fix the raciness just in case.