### PR TITLE
otel-config: fix rate limiting errors when writing metrics in prod/staging

### DIFF
--- a/modules/regional-service/otel-config/config.yaml
+++ b/modules/regional-service/otel-config/config.yaml
@@ -3,7 +3,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: "localhost"
-        scrape_interval: 10s
+        scrape_interval: 30s  # Conservative increase from 10s
         static_configs:
         # TODO: make this configurable
         - targets: ["localhost:2112"]
@@ -18,6 +18,10 @@ receivers:
             action: drop
           - source_labels: [ __name__ ]
             regex: '^go_.*'
+            action: drop
+          # Add these new filters for OpenTelemetry internal metrics
+          - source_labels: [ __name__ ]
+            regex: '^otel_scope_.*'
             action: drop
 
 processors:
@@ -34,7 +38,7 @@ processors:
     # batch metrics before sending to reduce API usage
     send_batch_max_size: 200
     send_batch_size: 200
-    timeout: 5s
+    timeout: 15s  # Conservative increase from 5s, stays well below scrape interval
 
   memory_limiter:
     # drop metrics if memory usage gets too high


### PR DESCRIPTION
# Problem

Our Cloud Run services are experiencing rate limiting errors when writing metrics to Google Cloud Monitoring:

```
rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: timeSeries[0-29] (example metric.type="prometheus.googleapis.com/grpc_client_handling_seconds/histogram", metric.labels={"service_name": "cve-remediation", "grpc_method": "GetPackageVersionMetadata", "team": "acceleration", "otel_scope_version": "0.130.0-dev", "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver", "grpc_service": "chainguard.datastore.registry.Registry", "grpc_type": "unary"}): write for resource=prometheus_target{namespace:,instance:localhost:2112,job:cve-remediation,cluster:__run__,location:us-central1} failed with: Points must be written in order. One or more of the points specified had an older start time than the most recent point.
error details: name = Unknown  desc = total_point_count:30  success_point_count:14  errors:{status:{code:3}  point_count:16}"
```

One or more points were written more frequently than the maximum sampling period configured for the metric.
The error indicates we're violating Google Cloud Monitoring's sampling rate limits by writing metrics too frequently, with multiple data points being submitted at identical timestamps.

## Root Cause

Aggressive scrape interval: 10s scraping with 5s batch timeout caused overlapping metric submissions
Missing metric filters: OpenTelemetry internal metrics like otel_scope_info were not being filtered out
High export frequency: Batches were being sent every 5 seconds, exceeding rate limits

## Solution

This PR implements the following changes to resolve rate limiting issues: