### PR TITLE
Fix service_instance_id attribute to pick up correct value

### DIFF
--- a/modules/cron/otel-config/config.yaml
+++ b/modules/cron/otel-config/config.yaml
@@ -43,7 +43,7 @@ processors:
     # between multiple otel sidecar instance uploading overlapping time series
     # to the same buckets.
     - key: service.instance.id
-      from_attribute: faas.id
+      from_attribute: faas.instance
       action: upsert
     # The `gcp` resourcedetection processor sets `faas.name` to the name of the
     # Cloud Run service or the Cloud Run job.

--- a/modules/regional-service/otel-config/config.yaml
+++ b/modules/regional-service/otel-config/config.yaml
@@ -52,7 +52,7 @@ processors:
     # between multiple otel sidecar instance uploading overlapping time series
     # to the same buckets.
     - key: service.instance.id
-      from_attribute: faas.id
+      from_attribute: faas.instance
       action: upsert
     # The `gcp` resourcedetection processor sets `faas.name` to the name of the
     # Cloud Run service or the Cloud Run job.


### PR DESCRIPTION
This has the potential of blowing up our metrics volume by quite a bit but is also the fix for all the duplicate timeseries warnings that we have, I think.

They look like this

```
rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: timeSeries[0-29] (example metric.type="prometheus.googleapis.com/grpc_client_handling_seconds/histogram", metric.labels={"service_name": "cve-remediation", "grpc_method": "GetPackageVersionMetadata", "team": "acceleration", "otel_scope_version": "0.130.0-dev", "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver", "grpc_service": "chainguard.datastore.registry.Registry", "grpc_type": "unary"}): write for resource=prometheus_target{namespace:,instance:localhost:2112,job:cve-remediation,cluster:__run__,location:us-central1} failed with: Points must be written in order. One or more of the points specified had an older start time than the most recent point.
error details: name = Unknown  desc = total_point_count:30  success_point_count:14  errors:{status:{code:3}  point_count:16}"
```

and my intiution is that they are currently happening, because our metrics are not written with the respective instance_id label and are using `localhost:2112` instead, causing duplication across instances.

---

Currently, we're not writing any service_instance_id attributes into our metrics at all. This is due to `faas.id` not existing. Instead, the attribute is called `faas.instance` and it contains the instance ID we're looking for.

See:
- https://github.com/open-telemetry/opentelemetry-go-contrib/blob/f9a279a2e22856e5c4c1456ba0922852978afeab/detectors/gcp/detector.go#L53
- https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/53263aed359cd5972cf09534ddaf462d3720144b/detectors/gcp/faas.go#L91-L94
- https://github.com/open-telemetry/opentelemetry-go/blob/f6f6b42cfe4836110a68dc8eba6e89fa5f4e6ceb/semconv/v1.34.0/attribute_group.go#L4657