### PR TITLE
dashboard: Filter HTTP request count metric by revision

### DIFF
--- a/modules/dashboard/sections/http/main.tf
+++ b/modules/dashboard/sections/http/main.tf
@@ -8,7 +8,7 @@ module "width" { source = "../width" }
 module "request_count" {
   source          = "../../widgets/xy"
   title           = "Request count"
-  filter          = concat(var.filter, ["metric.type=\"run.googleapis.com/request_count\""])
+  filter          = concat(var.filter, ["resource.type=\"cloud_run_revision\"", "metric.type=\"run.googleapis.com/request_count\""])
   group_by_fields = ["metric.label.\"response_code_class\""]
   primary_align   = "ALIGN_RATE"
   primary_reduce  = "REDUCE_SUM"


### PR DESCRIPTION
Currently, we're not filtering the request count metric by revision, causing the dashboard to say "Unspecified resource" and the graph to be wildly wrong. This fixes this oversight.