### PR TITLE
httpmetrics: Warn once if buckets are not setup

### DIFF
--- a/pkg/httpmetrics/transport.go
+++ b/pkg/httpmetrics/transport.go
@@ -182,7 +182,16 @@ func instrumentRoundTripperDuration(next http.RoundTripper) promhttp.RoundTrippe
 	}
 }
 
+var setupWarning sync.Once
+
 func bucketize(ctx context.Context, host string) string {
+	if buckets == nil && bucketSuffixes == nil {
+		setupWarning.Do(func() {
+			clog.WarnContext(ctx, "no buckets configured, use httpmetrics.SetBuckets or SetBucketSuffixes")
+		})
+		return "other"
+	}
+
 	// Check the exact matches first.
 	if b, ok := buckets[host]; ok {
 		return b


### PR DESCRIPTION
Instead of flooding the logs with all the hosts that aren't matching, this logs a warning about buckets not being setup once and then always returns "other".