### PR TITLE
httpmetrics: Introduce a skip option for bucketizing

### DIFF
--- a/pkg/httpmetrics/metrics_test.go
+++ b/pkg/httpmetrics/metrics_test.go
@@ -76,7 +76,7 @@ func TestBucketize(t *testing.T) {
 		{"rekor.sigstore.dev", "Rekor"},
 		{"issuer.enforce.dev", "issuer.enforce.dev"},
 	} {
-		if got := bucketize(t.Context(), c.host); got != c.bucket {
+		if got := bucketize(t.Context(), c.host, false); got != c.bucket {
 			t.Errorf("bucketize(%q) = %q, want %q", c.host, got, c.bucket)
 		}
 	}


### PR DESCRIPTION
For some HTTP clients, we can't reasonably bucket all the hosts they might reach out to (i.e. when the target is user-provided). To avoid flooding the logs with bucketing warnings, this introduces the option to skip the bucketizing for a given transport, so it can be used selectively.