### PR TITLE
httpmetrics: Backfill transport tests and fix to actually check the labels

### DIFF
--- a/pkg/httpmetrics/transport_test.go
+++ b/pkg/httpmetrics/transport_test.go
@@ -1,35 +1,88 @@
 package httpmetrics
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestTransport(t *testing.T) {
+	var mux sync.Mutex
+	requestSeen := make(chan struct{})
 	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Log("got request")
+		close(requestSeen)
+		mux.Lock()
+		defer mux.Unlock()
 	}))
 	defer s.Close()
 
-	resp, err := (&http.Client{Transport: Transport}).Get(s.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("want OK, got %s", resp.Status)
+	// Cause the request to "hang" for a bit to ensure we can observe in-flight metrics.
+	mux.Lock()
+
+	grp := errgroup.Group{}
+	grp.Go(func() error {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set(CeTypeHeader, "testce")
+		resp, err := (&http.Client{Transport: Transport}).Do(req)
+		if err != nil {
+			return fmt.Errorf("request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("want OK, got %s", resp.Status)
+		}
+		return nil
+	})
+
+	// Wait for the request to enter the server handler.
+	// This ensures that the in-flight metric is incremented before we check it.
+	<-requestSeen
+	if got := testutil.ToFloat64(mReqInFlight.With(prometheus.Labels{
+		"method":        http.MethodGet,
+		"host":          "other",
+		"service_name":  "unknown",
+		"revision_name": "unknown",
+		"ce_type":       "testce",
+	})); got != 1 {
+		t.Errorf("want metric in-flight = 1, got %f", got)
 	}
 
-	// Sample a metric to make sure labels are being properly applied.
-	if got := testutil.ToFloat64(mReqCount.MustCurryWith(prometheus.Labels{
-		"method": "get",
-		"code":   "200",
-		"host":   "other",
+	// Release the lock to allow the request to complete.
+	mux.Unlock()
+
+	// Wait for the request to finish.
+	if err := grp.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sample metrics to make sure labels are being properly applied.
+	if got := testutil.ToFloat64(mReqCount.With(prometheus.Labels{
+		"method":        http.MethodGet,
+		"code":          "200",
+		"host":          "other",
+		"service_name":  "unknown",
+		"revision_name": "unknown",
+		"ce_type":       "testce",
 	})); got != 1 {
 		t.Errorf("want metric count = 1, got %f", got)
+	}
+	if got := testutil.ToFloat64(mReqInFlight.With(prometheus.Labels{
+		"method":        http.MethodGet,
+		"host":          "other",
+		"service_name":  "unknown",
+		"revision_name": "unknown",
+		"ce_type":       "testce",
+	})); got != 0 {
+		t.Errorf("want metric in-flight = 0, got %f", got)
 	}
 }
 


### PR DESCRIPTION
Curried metrics don't seem to filter in testing at all, meaning that the labels can be whatever and the tests still pass. That's no bueno.

Instead, this asserts that the labels are all actually as expected.

It also backfills tests for the in-flight metric to ensure we're getting the metrics that we want.