### PR TITLE
httpmetrics: Fix setup shortcut to not depend on nil values

### DIFF
--- a/pkg/httpmetrics/transport.go
+++ b/pkg/httpmetrics/transport.go
@@ -217,7 +217,7 @@ func bucketize(ctx context.Context, host string, skip bool) string {
 		return "unbucketized"
 	}
 
-	if buckets == nil && bucketSuffixes == nil {
+	if len(buckets) == 0 && len(bucketSuffixes) == 0 {
 		setupWarning.Do(func() {
 			clog.WarnContext(ctx, "no buckets configured, use httpmetrics.SetBuckets or SetBucketSuffixes")
 		})


### PR DESCRIPTION
We actually initialize these maps and so they're not nit, but empty. Go off of that signal instead.