### PR TITLE
regional-X-service: default to GEN2

### DIFF
--- a/modules/regional-go-service/variables.tf
+++ b/modules/regional-go-service/variables.tf
@@ -199,7 +199,7 @@ variable "notification_channels" {
 variable "execution_environment" {
   description = "The execution environment for the service"
   type        = string
-  default     = "EXECUTION_ENVIRONMENT_GEN1"
+  default     = "EXECUTION_ENVIRONMENT_GEN2"
   validation {
     error_message = "Must be EXECUTION_ENVIRONMENT_GEN1 or EXECUTION_ENVIRONMENT_GEN2. Got ${var.execution_environment}"
     condition     = var.execution_environment == "EXECUTION_ENVIRONMENT_GEN1" || var.execution_environment == "EXECUTION_ENVIRONMENT_GEN2"

--- a/modules/regional-service/variables.tf
+++ b/modules/regional-service/variables.tf
@@ -194,7 +194,7 @@ variable "notification_channels" {
 variable "execution_environment" {
   description = "The execution environment for the service"
   type        = string
-  default     = "EXECUTION_ENVIRONMENT_GEN1"
+  default     = "EXECUTION_ENVIRONMENT_GEN2"
   validation {
     error_message = "Must be EXECUTION_ENVIRONMENT_GEN1 or EXECUTION_ENVIRONMENT_GEN2. Got ${var.execution_environment}"
     condition     = var.execution_environment == "EXECUTION_ENVIRONMENT_GEN1" || var.execution_environment == "EXECUTION_ENVIRONMENT_GEN2"


### PR DESCRIPTION
GEN2 is generally what we want, and I've been surprised more than twice lately that some service is running as GEN1.

I think we set GEN1 as the default for backward compatibility, and so we could slowly adopt GEN2, but I think we pretty much have everywhere, and even if we haven't I think we should.

