### PR TITLE
Need to disable delete protection for replicas to roll out fix

### DIFF
--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -103,6 +103,7 @@ resource "google_sql_database_instance" "replicas" {
   region               = each.value
   database_version     = var.database_version
   master_instance_name = google_sql_database_instance.this.name
+  deletion_protection  = var.replicas_deletion_protection
 
   replica_configuration {
     failover_target = false

--- a/modules/cloudsql-postgres/variables.tf
+++ b/modules/cloudsql-postgres/variables.tf
@@ -108,6 +108,12 @@ variable "read_replica_regions" {
   default     = []
 }
 
+variable "replicas_deletion_protection" {
+  description = "Enable deletion protection for read replicas."
+  type        = bool
+  default     = false
+}
+
 # Backup & Maintenance
 
 variable "backup_enabled" {


### PR DESCRIPTION
Follow up from https://github.com/chainguard-dev/terraform-infra-common/pull/989.  I understand why the main RW DB instance might need delete protection, but I'm not convinced the replicas do.  If they do, we can add this back as a variable, but we need to remove this to release replica change https://github.com/chainguard-dev/infra-images/actions/runs/16598749526/job/46952477048#step:20:31