### PR TITLE
Add ability to overwrite ssl_mode

### DIFF
--- a/modules/cloudsql-postgres/main.tf
+++ b/modules/cloudsql-postgres/main.tf
@@ -50,7 +50,7 @@ resource "google_sql_database_instance" "this" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network
-      ssl_mode        = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+      ssl_mode        = var.ssl_mode
     }
 
     backup_configuration {
@@ -123,7 +123,7 @@ resource "google_sql_database_instance" "replicas" {
     ip_configuration {
       ipv4_enabled    = false
       private_network = var.network
-      ssl_mode        = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+      ssl_mode        = var.ssl_mode
     }
 
     user_labels = merge(local.merged_labels, {

--- a/modules/cloudsql-postgres/variables.tf
+++ b/modules/cloudsql-postgres/variables.tf
@@ -24,6 +24,22 @@ variable "network" {
   type        = string
 }
 
+variable "ssl_mode" {
+  description = "SSL mode for the Cloud SQL instance. Default is TRUSTED_CLIENT_CERTIFICATE_REQUIRED."
+  type        = string
+  default     = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+
+  validation {
+    condition = contains([
+      "TRUSTED_CLIENT_CERTIFICATE_REQUIRED",
+      "ALLOW_UNENCRYPTED_AND_ENCRYPTED",
+      "ENCRYPTED_ONLY"
+    ], upper(var.ssl_mode))
+
+    error_message = "ssl_mode must be one of: TRUSTED_CLIENT_CERTIFICATE_REQUIRED, ALLOW_UNENCRYPTED_AND_ENCRYPTED, ENCRYPTED_ONLY."
+  }
+}
+
 variable "squad" {
   description = "Squad or team label applied to the instance (required)."
   type        = string


### PR DESCRIPTION
Reasoning for this is to debug the BQ->PG issue.  It looks as though the connector doesn't support `TRUSTED_CLIENT_CERTIFICATE_REQUIRED`.

This change leaves `TRUSTED_CLIENT_CERTIFICATE_REQUIRED` as the default and validates that any of the overrides are correct.