### PR TITLE
dynamic create the advanced_machine_features otherwise dont

### DIFF
--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -293,9 +293,12 @@ resource "google_container_node_pool" "pools" {
     labels          = each.value.labels
     resource_labels = merge(local.default_labels, local.squad_label, local.product_label, var.labels)
 
-    advanced_machine_features {
-      threads_per_core             = 0 // Must be set, but we want the default.
-      enable_nested_virtualization = each.value.enable_nested_virtualization
+    dynamic "advanced_machine_features" {
+      for_each = each.value.enable_nested_virtualization != null ? [1] : []
+      content {
+        threads_per_core             = 0 // Must be set, but we want the default.
+        enable_nested_virtualization = each.value.enable_nested_virtualization
+      }
     }
 
     shielded_instance_config {

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -58,7 +58,7 @@ variable "pools" {
     ephemeral_storage_local_ssd_count = optional(number, 0)
     spot                              = optional(bool, false)
     gvisor                            = optional(bool, false)
-    enable_nested_virtualization      = optional(bool, false)
+    enable_nested_virtualization      = optional(bool, null)
     enable_secure_boot                = optional(bool, false)
     enable_integrity_monitoring       = optional(bool, true)
     labels                            = optional(map(string), {})


### PR DESCRIPTION
For existing clusters that are using older versions of the module, these settings did not exist, and if we upgrade, it tries to replace the node pools, but at this point, we want to have a minimum disruptive change, so if the setting is not set, it will keep the old behavior.
