### PR TITLE
don't disable the api on destroy

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -45,6 +45,7 @@ resource "google_project_service" "redis_api" {
   project                    = var.project_id
   service                    = "redis.googleapis.com"
   disable_dependent_services = false
+  disable_on_destroy         = false
 }
 
 resource "google_redis_instance" "default" {


### PR DESCRIPTION
I can't think of a use case for also disabling the API on a destroy, this currently prevents this module from being used across multiple deploys (a destroy of one disables the api for the others!)