### PR TITLE
Explicit zone in role binds

### DIFF
--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -273,6 +273,7 @@ resource "google_iap_tunnel_instance_iam_member" "dev_os_login" {
 
   project  = var.project_id
   instance = google_compute_instance.bastion.name
+  zone     = var.zone
   role     = "roles/compute.osLogin"
   member   = each.key
 }
@@ -282,6 +283,7 @@ resource "google_iap_tunnel_instance_iam_member" "dev_iap_tunnel_resource_access
 
   project  = var.project_id
   instance = google_compute_instance.bastion.name
+  zone     = var.zone
   role     = "roles/iap.tunnelResourceAccessor"
   member   = each.key
 }
@@ -291,6 +293,7 @@ resource "google_iap_tunnel_instance_iam_member" "dev_service_account_user" {
 
   project  = var.project_id
   instance = google_compute_instance.bastion.name
+  zone     = var.zone
   role     = "roles/iam.serviceAccountUser"
   member   = each.key
 }


### PR DESCRIPTION
https://github.com/chainguard-dev/infra-images/actions/runs/16734636525/job/47370705137#step:20:35

It doesn't work to auto populate this.