### PR TITLE
githubreconciler: reuse existing comment state tracking from github-bots/sdk

### DIFF
--- a/modules/github-bots/sdk/comment_state.go
+++ b/modules/github-bots/sdk/comment_state.go
@@ -139,4 +139,3 @@ func (sm *CommentStateManager) BuildCommentWithState(message string, state inter
 func (sm *CommentStateManager) HasState(body string) bool {
 	return strings.Contains(body, sm.GetStateMarker()) && strings.Contains(body, sm.GetStateEndMarker())
 }
-

--- a/modules/github-bots/sdk/comment_state.go
+++ b/modules/github-bots/sdk/comment_state.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2025 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// CommentStateManager helps manage JSON state embedded in GitHub comments.
+type CommentStateManager struct {
+	Identity string
+}
+
+// NewCommentStateManager creates a new state manager with the given identity.
+func NewCommentStateManager(identity string) *CommentStateManager {
+	return &CommentStateManager{
+		Identity: identity,
+	}
+}
+
+// GetStateMarker returns the HTML comment marker for state data.
+func (sm *CommentStateManager) GetStateMarker() string {
+	return fmt.Sprintf("<!--%s-state-->", sm.Identity)
+}
+
+// GetStateEndMarker returns the HTML comment end marker for state data.
+func (sm *CommentStateManager) GetStateEndMarker() string {
+	return fmt.Sprintf("<!--/%s-state-->", sm.Identity)
+}
+
+// GetIdentityMarker returns the HTML comment marker for the identity.
+func (sm *CommentStateManager) GetIdentityMarker() string {
+	return fmt.Sprintf("<!--%s-->", sm.Identity)
+}
+
+// EmbedState embeds JSON state data in a comment string.
+// The state is hidden in HTML comments between state markers.
+func (sm *CommentStateManager) EmbedState(message string, state interface{}) (string, error) {
+	stateJSON, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	var content strings.Builder
+
+	// Identity marker
+	content.WriteString(sm.GetIdentityMarker())
+	content.WriteString("\n\n")
+
+	// User-visible message
+	content.WriteString(message)
+	content.WriteString("\n\n")
+
+	// State data (hidden in HTML comment)
+	content.WriteString(sm.GetStateMarker())
+	content.WriteString("\n<!--\n")
+	content.WriteString(string(stateJSON))
+	content.WriteString("\n-->\n")
+	content.WriteString(sm.GetStateEndMarker())
+
+	return content.String(), nil
+}
+
+// ExtractState extracts JSON state from a comment body.
+// Returns nil if no state is found.
+func (sm *CommentStateManager) ExtractState(body string, state interface{}) error {
+	stateMarker := sm.GetStateMarker()
+	stateEndMarker := sm.GetStateEndMarker()
+
+	// Find the state data between markers
+	startIdx := strings.Index(body, stateMarker)
+	if startIdx == -1 {
+		return fmt.Errorf("state marker not found")
+	}
+	startIdx += len(stateMarker)
+
+	endIdx := strings.Index(body[startIdx:], stateEndMarker)
+	if endIdx == -1 {
+		return fmt.Errorf("malformed state: missing end marker")
+	}
+
+	stateJSON := strings.TrimSpace(body[startIdx : startIdx+endIdx])
+
+	// Remove HTML comment wrapper if present
+	stateJSON = strings.TrimPrefix(stateJSON, "<!--")
+	stateJSON = strings.TrimSuffix(stateJSON, "-->")
+	stateJSON = strings.TrimSpace(stateJSON)
+
+	if err := json.Unmarshal([]byte(stateJSON), state); err != nil {
+		return fmt.Errorf("failed to unmarshal state: %w", err)
+	}
+
+	return nil
+}
+
+// BuildCommentWithState builds a comment with an identity marker, message, and embedded state.
+// This combines the identity marker, user message, and hidden state into a single comment.
+func (sm *CommentStateManager) BuildCommentWithState(message string, state interface{}, headerFunc func() string) (string, error) {
+	stateJSON, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	var content strings.Builder
+
+	// Identity marker
+	content.WriteString(sm.GetIdentityMarker())
+	content.WriteString("\n\n")
+
+	// Optional header (e.g., bot info)
+	if headerFunc != nil {
+		header := headerFunc()
+		if header != "" {
+			content.WriteString(header)
+			content.WriteString("\n\n---\n\n")
+		}
+	}
+
+	// User-visible message
+	content.WriteString(message)
+	content.WriteString("\n\n")
+
+	// State data (hidden in HTML comment)
+	content.WriteString(sm.GetStateMarker())
+	content.WriteString("\n<!--\n")
+	content.WriteString(string(stateJSON))
+	content.WriteString("\n-->\n")
+	content.WriteString(sm.GetStateEndMarker())
+
+	return content.String(), nil
+}
+
+// HasState checks if a comment body contains state for this identity.
+func (sm *CommentStateManager) HasState(body string) bool {
+	return strings.Contains(body, sm.GetStateMarker()) && strings.Contains(body, sm.GetStateEndMarker())
+}
+

--- a/pkg/githubreconciler/reconciler.go
+++ b/pkg/githubreconciler/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
 	"github.com/google/go-github/v72/github"
 )
 
@@ -61,7 +62,7 @@ type Reconciler struct {
 	clientCache *ClientCache
 
 	// stateManager handles state persistence in GitHub comments.
-	stateManager *StateManager
+	stateManager *sdk.CommentStateManager
 }
 
 // Option configures a Reconciler.
@@ -75,7 +76,7 @@ func WithReconciler(f ReconcilerFunc) Option {
 }
 
 // WithStateManager sets a custom state manager.
-func WithStateManager(sm *StateManager) Option {
+func WithStateManager(sm *sdk.CommentStateManager) Option {
 	return func(r *Reconciler) {
 		r.stateManager = sm
 	}
@@ -93,7 +94,7 @@ func NewReconciler(cc *ClientCache, opts ...Option) *Reconciler {
 
 	// Use a default state manager if none provided
 	if r.stateManager == nil {
-		r.stateManager = NewStateManager("github-reconciler")
+		r.stateManager = sdk.NewCommentStateManager("github-reconciler")
 	}
 
 	return r
@@ -125,6 +126,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, url string) error {
 }
 
 // GetStateManager returns the state manager for accessing state operations.
-func (r *Reconciler) GetStateManager() *StateManager {
+func (r *Reconciler) GetStateManager() *sdk.CommentStateManager {
 	return r.stateManager
 }

--- a/pkg/githubreconciler/reconciler_test.go
+++ b/pkg/githubreconciler/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chainguard-dev/terraform-infra-common/modules/github-bots/sdk"
 	"github.com/google/go-github/v72/github"
 	"golang.org/x/oauth2"
 )
@@ -37,12 +38,12 @@ func TestNewReconciler(t *testing.T) {
 	if r.stateManager == nil {
 		t.Error("Expected default state manager to be created")
 	}
-	if r.stateManager.Identity() != "github-reconciler" {
-		t.Errorf("Expected default identity 'github-reconciler', got %s", r.stateManager.Identity())
+	if r.stateManager.Identity != "github-reconciler" {
+		t.Errorf("Expected default identity 'github-reconciler', got %s", r.stateManager.Identity)
 	}
 
 	// Test with custom state manager
-	customSM := NewStateManager("custom-identity")
+	customSM := sdk.NewCommentStateManager("custom-identity")
 	r2 := NewReconciler(cc, WithStateManager(customSM))
 	if r2.stateManager != customSM {
 		t.Error("Expected custom state manager to be used")
@@ -225,19 +226,19 @@ func TestReconciler_GetStateManager(t *testing.T) {
 	if sm1 == nil {
 		t.Fatal("GetStateManager() returned nil")
 	}
-	if sm1.Identity() != "github-reconciler" {
-		t.Errorf("GetStateManager() identity = %v, want %v", sm1.Identity(), "github-reconciler")
+	if sm1.Identity != "github-reconciler" {
+		t.Errorf("GetStateManager() identity = %v, want %v", sm1.Identity, "github-reconciler")
 	}
 
 	// Test with custom state manager
-	customSM := NewStateManager("custom-id")
+	customSM := sdk.NewCommentStateManager("custom-id")
 	r2 := NewReconciler(cc, WithStateManager(customSM))
 	sm2 := r2.GetStateManager()
 	if sm2 != customSM {
 		t.Error("GetStateManager() did not return the custom state manager")
 	}
-	if sm2.Identity() != "custom-id" {
-		t.Errorf("GetStateManager() identity = %v, want %v", sm2.Identity(), "custom-id")
+	if sm2.Identity != "custom-id" {
+		t.Errorf("GetStateManager() identity = %v, want %v", sm2.Identity, "custom-id")
 	}
 }
 


### PR DESCRIPTION
Reusing that code, which is already in use elsewhere, keeps us from having to maintain two copies of this code, and improves the existing code by having it use comment pagination, and improves githubreconciler by having it use sdk.GitHubClient, which is rate-limit-aware.

Q: do we want bots to specify their "name" at all, or should they express that via their identity / octo-sts policy name? We want each bot to have its own identity right? So why also make them have unique names.