### PR TITLE
Fix Orca secret listing alerting

### DIFF
--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -25,12 +25,9 @@ resource "google_secret_manager_secret_version" "placeholder" {
 locals {
   accessors       = [for sa in concat([var.service-account], var.service-accounts) : "serviceAccount:${sa}" if sa != ""]
   accessor_emails = [for sa in concat([var.service-account], var.service-accounts) : sa if sa != ""]
-<<<<<<< Updated upstream
   # Extract the email portion of the authorized adder member
   authorized_adder_email = strcontains(var.authorized-adder, ":") ? split(":", var.authorized-adder)[1] : var.authorized-adder
-=======
-  orca_sa         = "sa-chainguard-9419b821e0@orca-service-accounts-prod.iam.gserviceaccount.com"
->>>>>>> Stashed changes
+  orca_sa                = "sa-chainguard-9419b821e0@orca-service-accounts-prod.iam.gserviceaccount.com"
 
   default_labels = {
     basename(abspath(path.module)) = var.name
@@ -98,18 +95,15 @@ resource "google_monitoring_alert_policy" "anomalous-secret-access" {
         protoPayload.authenticationInfo.principalEmail=~"${join("|", local.accessor_emails)}"
         protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.(AccessSecretVersion|GetSecretVersion)"
       )
-<<<<<<< Updated upstream
       -- Ignore the identity that is authorized to manipulate secret versions.
       -(
         protoPayload.authenticationInfo.principalEmail="${local.authorized_adder_email}"
         protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.(DestroySecretVersion|AddSecretVersion|EnableSecretVersion)"
-=======
-
+      )
       -- Ignore the Orca scanner SA performing benign actions.
       -(
         protoPayload.authenticationInfo.principalEmail=~"${local.orca_sa}"
         protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions"
->>>>>>> Stashed changes
       )
       EOT
 

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -25,8 +25,12 @@ resource "google_secret_manager_secret_version" "placeholder" {
 locals {
   accessors       = [for sa in concat([var.service-account], var.service-accounts) : "serviceAccount:${sa}" if sa != ""]
   accessor_emails = [for sa in concat([var.service-account], var.service-accounts) : sa if sa != ""]
+<<<<<<< Updated upstream
   # Extract the email portion of the authorized adder member
   authorized_adder_email = strcontains(var.authorized-adder, ":") ? split(":", var.authorized-adder)[1] : var.authorized-adder
+=======
+  orca_sa         = "sa-chainguard-9419b821e0@orca-service-accounts-prod.iam.gserviceaccount.com"
+>>>>>>> Stashed changes
 
   default_labels = {
     basename(abspath(path.module)) = var.name
@@ -94,10 +98,18 @@ resource "google_monitoring_alert_policy" "anomalous-secret-access" {
         protoPayload.authenticationInfo.principalEmail=~"${join("|", local.accessor_emails)}"
         protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.(AccessSecretVersion|GetSecretVersion)"
       )
+<<<<<<< Updated upstream
       -- Ignore the identity that is authorized to manipulate secret versions.
       -(
         protoPayload.authenticationInfo.principalEmail="${local.authorized_adder_email}"
         protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.(DestroySecretVersion|AddSecretVersion|EnableSecretVersion)"
+=======
+
+      -- Ignore the Orca scanner SA performing benign actions.
+      -(
+        protoPayload.authenticationInfo.principalEmail=~"${local.orca_sa}"
+        protoPayload.methodName=~"google.cloud.secretmanager.v1.SecretManagerService.ListSecretVersions"
+>>>>>>> Stashed changes
       )
       EOT
 


### PR DESCRIPTION
This PR adds an exclusion for all the `Abnormal Secret Access:` GCP alerts so that the [Orca](https://orca.security/) service account is excluded for `ListSecretVersions` operations.

This is expected behavior.