### PR TITLE
drop grpc dial options with storage new client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.8.0
 	cloud.google.com/go/profiler v0.4.3
 	cloud.google.com/go/pubsub/v2 v2.0.0
-	cloud.google.com/go/storage v1.56.0
+	cloud.google.com/go/storage v1.56.1
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.29.0
 	github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270
 	github.com/bradleyfalzon/ghinstallation/v2 v2.16.0

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ cloud.google.com/go/pubsub/v2 v2.0.0 h1:0qS6mRJ41gD1lNmM/vdm6bR7DQu6coQcVwD+VPf0
 cloud.google.com/go/pubsub/v2 v2.0.0/go.mod h1:0aztFxNzVQIRSZ8vUr79uH2bS3jwLebwK6q1sgEub+E=
 cloud.google.com/go/storage v1.56.0 h1:iixmq2Fse2tqxMbWhLWC9HfBj1qdxqAmiK8/eqtsLxI=
 cloud.google.com/go/storage v1.56.0/go.mod h1:Tpuj6t4NweCLzlNbw9Z9iwxEkrSem20AetIeH/shgVU=
+cloud.google.com/go/storage v1.56.1 h1:n6gy+yLnHn0hTwBFzNn8zJ1kqWfR91wzdM8hjRF4wP0=
+cloud.google.com/go/storage v1.56.1/go.mod h1:C9xuCZgFl3buo2HZU/1FncgvvOgTAs/rnh4gF4lMg0s=
 cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4=
 cloud.google.com/go/trace v1.11.6/go.mod h1:GA855OeDEBiBMzcckLPE2kDunIpC72N+Pq8WFieFjnI=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=

--- a/modules/workqueue/cmd/dispatcher/main.go
+++ b/modules/workqueue/cmd/dispatcher/main.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"time"
 
-	"chainguard.dev/go-grpc-kit/pkg/options"
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/clog"
 	_ "github.com/chainguard-dev/clog/gcp/init"
@@ -50,7 +49,7 @@ func main() {
 	var wq workqueue.Interface
 	switch env.Mode {
 	case "gcs":
-		cl, err := storage.NewClient(ctx, options.ClientOptions()...)
+		cl, err := storage.NewClient(ctx)
 		if err != nil {
 			log.Panicf("Failed to create client: %v", err)
 		}

--- a/modules/workqueue/cmd/receiver/main.go
+++ b/modules/workqueue/cmd/receiver/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"chainguard.dev/go-grpc-kit/pkg/duplex"
-	"chainguard.dev/go-grpc-kit/pkg/options"
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/clog"
 	_ "github.com/chainguard-dev/clog/gcp/init"
@@ -53,7 +52,7 @@ func main() {
 
 	switch env.Mode {
 	case "gcs":
-		cl, err := storage.NewClient(ctx, options.ClientOptions()...)
+		cl, err := storage.NewClient(ctx)
 		if err != nil {
 			log.Panicf("Failed to create client: %v", err)
 		}


### PR DESCRIPTION
fix 
```
storage client: WithHTTPClient is incompatible with gRPC dial options
```

our client options are grpc dial options, which isnt compatible with storage, which uses WithHTTPClient.
this worked previously as the options wasnt passed through to the service, but with 1.56.1
in particular, this fix, https://github.com/googleapis/google-cloud-go/pull/12615