### PR TITLE
workqueue: Add priority class to latency metrics

### DIFF
--- a/pkg/workqueue/gcs/gcs.go
+++ b/pkg/workqueue/gcs/gcs.go
@@ -441,8 +441,9 @@ func (o *inProgressKey) Complete(ctx context.Context) error {
 	defer o.rw.RUnlock()
 
 	mWorkLatency.With(prometheus.Labels{
-		"service_name":  env.KnativeServiceName,
-		"revision_name": env.KnativeRevisionName,
+		"service_name":   env.KnativeServiceName,
+		"revision_name":  env.KnativeRevisionName,
+		"priority_class": priorityClass(o.priority),
 	}).Observe(time.Now().UTC().Sub(o.attrs.Created).Seconds())
 
 	// Best-effort delete of the dead-letter object, if it exists.
@@ -579,8 +580,9 @@ func (q *queuedKey) Start(ctx context.Context) (workqueue.OwnedInProgressKey, er
 		}
 	}
 	mWaitLatency.With(prometheus.Labels{
-		"service_name":  env.KnativeServiceName,
-		"revision_name": env.KnativeRevisionName,
+		"service_name":   env.KnativeServiceName,
+		"revision_name":  env.KnativeRevisionName,
+		"priority_class": priorityClass(q.priority),
 	}).Observe(time.Now().UTC().Sub(waitStart).Seconds())
 
 	// Create a copier to copy the source object, and then we will delete it

--- a/pkg/workqueue/gcs/metrics.go
+++ b/pkg/workqueue/gcs/metrics.go
@@ -7,6 +7,7 @@ package gcs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -64,7 +65,7 @@ var (
 			Help:    "The duration taken to process a key.",
 			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 45, 60, 120, 240, 480, 960, 3600, 7200},
 		},
-		[]string{"service_name", "revision_name"},
+		[]string{"service_name", "revision_name", "priority_class"},
 	)
 	mWaitLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -72,7 +73,7 @@ var (
 			Help:    "The duration the key waited to start.",
 			Buckets: []float64{.25, .5, 1, 2.5, 5, 10, 20, 30, 45, 60, 120, 240, 480, 960, 3600, 7200},
 		},
-		[]string{"service_name", "revision_name"},
+		[]string{"service_name", "revision_name", "priority_class"},
 	)
 	mAddedKeys = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -96,3 +97,8 @@ var (
 		[]string{"service_name", "revision_name"},
 	)
 )
+
+// priorityClass converts a priority value to a priority class label.
+func priorityClass(priority int64) string {
+	return fmt.Sprintf("%dxx", priority/100)
+}

--- a/pkg/workqueue/gcs/metrics_test.go
+++ b/pkg/workqueue/gcs/metrics_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gcs
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPriorityClass(t *testing.T) {
+	tests := []struct {
+		priority int64
+		want     string
+	}{
+		{priority: 0, want: "0xx"},
+		{priority: 1, want: "0xx"},
+		{priority: 99, want: "0xx"},
+		{priority: 100, want: "1xx"},
+		{priority: 199, want: "1xx"},
+		{priority: 200, want: "2xx"},
+		{priority: 999, want: "9xx"},
+		{priority: 1000, want: "10xx"},
+		{priority: -1, want: "0xx"},
+		{priority: -100, want: "-1xx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("priority_%d", tt.priority), func(t *testing.T) {
+			got := priorityClass(tt.priority)
+			if got != tt.want {
+				t.Errorf("priorityClass(%d) = %q, want %q", tt.priority, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will help us separate out metrics between priorities.

Used "${priority/100}xx" in order to be flexible here, but clients share responsibility here in choosing reasonable ranges. We can scope/cap this later if necessary.