### PR TITLE
workqueue: add global scope to fix deduplication and single-worker gu…

### DIFF
--- a/modules/workqueue/main.tf
+++ b/modules/workqueue/main.tf
@@ -17,6 +17,7 @@ locals {
   merged_labels = merge(local.default_labels, local.squad_label, local.product_label, var.labels)
 }
 
+// Storage buckets: regional and global
 resource "google_storage_bucket" "workqueue" {
   for_each = var.regions
 
@@ -30,6 +31,18 @@ resource "google_storage_bucket" "workqueue" {
   public_access_prevention    = "enforced"
 }
 
+resource "google_storage_bucket" "global-workqueue" {
+  name          = "${var.name}-global"
+  project       = var.project_id
+  location      = var.multi_regional_location
+  force_destroy = true
+  labels        = local.merged_labels
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+}
+
+// Storage IAM: regional and global
 resource "google_storage_bucket_iam_binding" "authorize-access" {
   for_each = var.regions
 
@@ -41,7 +54,16 @@ resource "google_storage_bucket_iam_binding" "authorize-access" {
   ]
 }
 
-// Create a topic per region for the regional buckets to route events to.
+resource "google_storage_bucket_iam_binding" "global-authorize-access" {
+  bucket = google_storage_bucket.global-workqueue.name
+  role   = "roles/storage.admin"
+  members = [
+    "serviceAccount:${google_service_account.receiver.email}",
+    "serviceAccount:${google_service_account.dispatcher.email}",
+  ]
+}
+
+// Pub/Sub topics: regional and global
 resource "google_pubsub_topic" "object-change-notifications" {
   for_each = var.regions
   name     = "${var.name}-${each.key}"
@@ -52,8 +74,20 @@ resource "google_pubsub_topic" "object-change-notifications" {
   }
 }
 
+resource "google_pubsub_topic" "global-object-change-notifications" {
+  for_each = var.regions
+
+  name   = "${var.name}-global-${each.key}"
+  labels = local.merged_labels
+
+  message_storage_policy {
+    allowed_persistence_regions = [each.key]
+  }
+}
+
 data "google_storage_project_service_account" "gcs_account" {}
 
+// Pub/Sub IAM: regional and global
 resource "google_pubsub_topic_iam_binding" "gcs-publishes-to-topic" {
   for_each = var.regions
 
@@ -62,6 +96,15 @@ resource "google_pubsub_topic_iam_binding" "gcs-publishes-to-topic" {
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
 
+resource "google_pubsub_topic_iam_binding" "global-gcs-publishes-to-topic" {
+  for_each = var.regions
+
+  topic   = google_pubsub_topic.global-object-change-notifications[each.key].id
+  role    = "roles/pubsub.publisher"
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+// Storage notifications: regional and global
 resource "google_storage_notification" "object-change-notifications" {
   for_each = var.regions
 
@@ -70,4 +113,14 @@ resource "google_storage_notification" "object-change-notifications" {
   bucket         = google_storage_bucket.workqueue[each.key].name
   payload_format = "JSON_API_V1"
   topic          = google_pubsub_topic.object-change-notifications[each.key].id
+}
+
+resource "google_storage_notification" "global-object-change-notifications" {
+  for_each = var.regions
+
+  depends_on = [google_pubsub_topic_iam_binding.global-gcs-publishes-to-topic]
+
+  bucket         = google_storage_bucket.global-workqueue.name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.global-object-change-notifications[each.key].id
 }

--- a/modules/workqueue/receiver.tf
+++ b/modules/workqueue/receiver.tf
@@ -53,8 +53,12 @@ module "receiver-service" {
       ]
       regional-env = [
         {
-          name  = "WORKQUEUE_BUCKET"
-          value = { for k, v in google_storage_bucket.workqueue : k => v.name }
+          name = "WORKQUEUE_BUCKET"
+          value = var.scope == "global" ? {
+            for k, v in var.regions : k => google_storage_bucket.global-workqueue.name
+            } : {
+            for k, v in google_storage_bucket.workqueue : k => v.name
+          }
         },
       ]
     }

--- a/modules/workqueue/variables.tf
+++ b/modules/workqueue/variables.tf
@@ -59,3 +59,25 @@ variable "product" {
   type        = string
   default     = "unknown"
 }
+
+variable "scope" {
+  description = "The scope of the workqueue: 'regional' for region-specific workqueues or 'global' for a single multi-regional workqueue."
+  type        = string
+  default     = "regional"
+
+  validation {
+    condition     = contains(["regional", "global"], var.scope)
+    error_message = "scope must be either 'regional' or 'global'."
+  }
+}
+
+variable "multi_regional_location" {
+  description = "The multi-regional location for the global workqueue bucket (e.g., 'US', 'EU', 'ASIA'). Only used when scope='global'."
+  type        = string
+  default     = "US"
+
+  validation {
+    condition     = contains(["US", "EU", "ASIA"], var.multi_regional_location)
+    error_message = "multi_regional_location must be one of 'US', 'EU', or 'ASIA'."
+  }
+}


### PR DESCRIPTION
…arantees

The regional architecture (separate buckets per region) breaks two key workqueue properties:
- Deduplication: same key can exist in multiple regional buckets
- Single worker: multiple regional dispatchers can process same logical key

Add `scope` variable accepting "regional" (default) or "global". When global, all regions use a single multi-regional bucket to restore proper workqueue semantics.