### PR TITLE
Add time to completion metrics

### DIFF
--- a/modules/workqueue/dashboard.tf
+++ b/modules/workqueue/dashboard.tf
@@ -21,10 +21,10 @@ module "attempts-at-completion" {
   thresholds   = var.max-retry > 0 ? [var.max-retry] : []
 }
 
-module "total-time-to-completion" {
+module "time-to-completion" {
   source       = "../dashboard/widgets/xy-promql"
-  title        = "Total time to completion (50p/95p by priority)"
-  promql_query = "histogram_quantile(0.50, rate(workqueue_total_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class) or histogram_quantile(0.95, rate(workqueue_total_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class)"
+  title        = "Time to completion (50p/95p by priority)"
+  promql_query = "histogram_quantile(0.50, rate(workqueue_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class) or histogram_quantile(0.95, rate(workqueue_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class)"
 }
 
 module "max-attempts" {
@@ -218,7 +218,7 @@ locals {
       xPos   = local.col[0],
       height = local.unit,
       width  = local.unit,
-      widget = module.total-time-to-completion.widget,
+      widget = module.time-to-completion.widget,
     }
     ],
     var.max-retry > 0 ? [

--- a/modules/workqueue/dashboard.tf
+++ b/modules/workqueue/dashboard.tf
@@ -15,10 +15,16 @@ module "dispatcher-logs" {
 }
 
 module "attempts-at-completion" {
-  source = "../dashboard/widgets/xy-promql"
-  title  = "Attempts at completion (95p over 5m)"
+  source       = "../dashboard/widgets/xy-promql"
+  title        = "Attempts at completion (95p over 5m)"
   promql_query = "histogram_quantile(0.95, rate(workqueue_attempts_at_completion_bucket{service_name=\"${var.name}-dsp\"}[5m]))"
-  thresholds = var.max-retry > 0 ? [var.max-retry] : []
+  thresholds   = var.max-retry > 0 ? [var.max-retry] : []
+}
+
+module "total-time-to-completion" {
+  source       = "../dashboard/widgets/xy-promql"
+  title        = "Total time to completion (50p/95p by priority)"
+  promql_query = "histogram_quantile(0.50, rate(workqueue_total_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class) or histogram_quantile(0.95, rate(workqueue_total_time_to_completion_seconds_bucket{service_name=\"${var.name}-dsp\"}[5m])) by (priority_class)"
 }
 
 module "max-attempts" {
@@ -206,6 +212,13 @@ locals {
       height = local.unit,
       width  = local.unit,
       widget = module.max-attempts.widget,
+    },
+    {
+      yPos   = local.unit * 3,
+      xPos   = local.col[0],
+      height = local.unit,
+      width  = local.unit,
+      widget = module.total-time-to-completion.widget,
     }
     ],
     var.max-retry > 0 ? [

--- a/pkg/workqueue/doc.go
+++ b/pkg/workqueue/doc.go
@@ -8,4 +8,23 @@ SPDX-License-Identifier: Apache-2.0
 
 // Package workqueue contains an interface for a simple key
 // workqueue abstraction.
+//
+// # Metrics
+//
+// The GCS implementation exports the following Prometheus metrics:
+//
+//   - workqueue_in_progress_keys: The number of keys currently being processed
+//   - workqueue_queued_keys: The number of keys currently in the backlog
+//   - workqueue_notbefore_keys: The number of keys waiting on a 'not before' time
+//   - workqueue_max_attempts: The maximum number of attempts for any queued or in-progress task
+//   - workqueue_task_max_attempts: The maximum number of attempts for a given task above 20
+//   - workqueue_process_latency_seconds: The duration taken to process a key
+//   - workqueue_wait_latency_seconds: The duration the key waited to start
+//   - workqueue_added_keys: The total number of queue requests
+//   - workqueue_deduped_keys: The total number of keys that were deduped
+//   - workqueue_attempts_at_completion: The number of attempts for successfully completed tasks
+//   - workqueue_dead_lettered_keys: The number of keys currently in the dead letter queue
+//   - workqueue_time_to_completion_seconds: The time from first queue to final outcome (success or dead-letter). The metric captures the full lifecycle duration including all retry attempts and backoff delays.
+//
+// All metrics include service_name and revision_name labels. Additional labels vary by metric.
 package workqueue

--- a/pkg/workqueue/gcs/gcs.go
+++ b/pkg/workqueue/gcs/gcs.go
@@ -453,8 +453,8 @@ func (o *inProgressKey) Complete(ctx context.Context) error {
 		"revision_name": env.KnativeRevisionName,
 	}).Observe(float64(attempts))
 
-	// Record total time to completion
-	mTotalTimeToCompletion.With(prometheus.Labels{
+	// Record time to completion
+	mTimeToCompletion.With(prometheus.Labels{
 		"service_name":   env.KnativeServiceName,
 		"revision_name":  env.KnativeRevisionName,
 		"priority_class": priorityClass(o.priority),
@@ -500,8 +500,8 @@ func (o *inProgressKey) Deadletter(ctx context.Context) error {
 	// Add metadata about when the key was dead-lettered
 	copier.Metadata[failedTimeMetadataKey] = time.Now().UTC().Format(time.RFC3339)
 
-	// Record total time to completion for dead-lettered task
-	mTotalTimeToCompletion.With(prometheus.Labels{
+	// Record time to completion for dead-lettered task
+	mTimeToCompletion.With(prometheus.Labels{
 		"service_name":   env.KnativeServiceName,
 		"revision_name":  env.KnativeRevisionName,
 		"priority_class": priorityClass(o.priority),

--- a/pkg/workqueue/gcs/metrics.go
+++ b/pkg/workqueue/gcs/metrics.go
@@ -104,10 +104,10 @@ var (
 		},
 		[]string{"service_name", "revision_name"},
 	)
-	mTotalTimeToCompletion = promauto.NewHistogramVec(
+	mTimeToCompletion = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "workqueue_total_time_to_completion_seconds",
-			Help:    "The total time from first queue to final outcome (success or dead-letter)",
+			Name:    "workqueue_time_to_completion_seconds",
+			Help:    "The time from first queue to final outcome (success or dead-letter). The metric captures the full lifecycle duration including all retry attempts and backoff delays.",
 			Buckets: []float64{5, 10, 20, 30, 45, 60, 120, 240, 480, 960, 3600 /* 1h */, 7200 /* 2h */, 14400 /* 4h */, 28800 /* 8h */, 43200 /* 12h */, 86400 /* 1d */, 172800 /* 2d */, 259200 /* 3d */},
 		},
 		[]string{"service_name", "revision_name", "priority_class", "status"},

--- a/pkg/workqueue/gcs/metrics.go
+++ b/pkg/workqueue/gcs/metrics.go
@@ -104,6 +104,14 @@ var (
 		},
 		[]string{"service_name", "revision_name"},
 	)
+	mTotalTimeToCompletion = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "workqueue_total_time_to_completion_seconds",
+			Help:    "The total time from first queue to final outcome (success or dead-letter)",
+			Buckets: []float64{5, 10, 20, 30, 45, 60, 120, 240, 480, 960, 3600 /* 1h */, 7200 /* 2h */, 14400 /* 4h */, 28800 /* 8h */, 43200 /* 12h */, 86400 /* 1d */, 172800 /* 2d */, 259200 /* 3d */},
+		},
+		[]string{"service_name", "revision_name", "priority_class", "status"},
+	)
 )
 
 // priorityClass converts a priority value to a priority class label.


### PR DESCRIPTION
We want to capture the statistics about how long it takes a task from first requested to completion, including all retries and backoff.