### PR TITLE
secret: remove the lifecycle prevent destroy block from placeholder secret version

### DIFF
--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -17,9 +17,10 @@ resource "google_secret_manager_secret_version" "placeholder" {
   secret      = google_secret_manager_secret.this.id
   secret_data = "placeholder"
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # We don't prevent this version from being destroyed,
+  # since it is meant as a bootstrapping step when creating new
+  # secrets. Once populated with a legitimate value, this
+  # placeholder is no longer needed.
 }
 
 locals {


### PR DESCRIPTION
The `placeholder` secret version is meant to assist with bootstrapping. However, due to the `prevent_destroy` block, callers can't drop the `create_placeholder_version` input var once the secret has been populated with a legitimate value. To allow callers to simplify their module configurations after bootstrap, drop the `lifecycle` block from this secret version.