### PR TITLE
feat: cpu_idle for ingress, workqueue, reconciler

### DIFF
--- a/modules/cloudevent-broker/README.md
+++ b/modules/cloudevent-broker/README.md
@@ -109,6 +109,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cpu_idle"></a> [cpu\_idle](#input\_cpu\_idle) | Set to false for a region in order to use instance-based billing. Defaults to true. | `map(bool)` | `{}` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable delete protection for the service. | `bool` | `true` | no |
 | <a name="input_enable_profiler"></a> [enable\_profiler](#input\_enable\_profiler) | Enable cloud profiler. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the broker resources. | `map(string)` | `{}` | no |

--- a/modules/cloudevent-broker/ingress.tf
+++ b/modules/cloudevent-broker/ingress.tf
@@ -47,6 +47,7 @@ module "this" {
       resources = {
         limits = var.limits
       }
+      regional-cpu-idle = var.cpu_idle
     }
   }
 

--- a/modules/cloudevent-broker/variables.tf
+++ b/modules/cloudevent-broker/variables.tf
@@ -70,3 +70,9 @@ variable "deletion_protection" {
   description = "Whether to enable delete protection for the service."
   default     = true
 }
+
+variable "cpu_idle" {
+  description = "Set to false for a region in order to use instance-based billing. Defaults to true."
+  type        = map(bool)
+  default     = {}
+}

--- a/modules/regional-go-reconciler/README.md
+++ b/modules/regional-go-reconciler/README.md
@@ -156,6 +156,7 @@ No resources.
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | The service account as which to run the reconciler service. | `string` | n/a | yes |
 | <a name="input_squad"></a> [squad](#input\_squad) | The squad that owns the service. | `string` | `""` | no |
 | <a name="input_volumes"></a> [volumes](#input\_volumes) | The volumes to attach to the service. | <pre>list(object({<br/>    name = string<br/>    empty_dir = optional(object({<br/>      medium     = optional(string, "MEMORY")<br/>      size_limit = optional(string, "1Gi")<br/>    }), null)<br/>    csi = optional(object({<br/>      driver = string<br/>      volume_attributes = optional(object({<br/>        bucketName = string<br/>      }), null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_workqueue_cpu_idle"></a> [workqueue\_cpu\_idle](#input\_workqueue\_cpu\_idle) | Set to false for a region in order to use instance-based billing for workqueue services (dispatcher and receiver). Defaults to true. To control reconciler cpu\_idle, use the 'regional-cpu-idle' field in the 'containers' variable. | `map(map(bool))` | <pre>{<br/>  "dispatcher": {},<br/>  "receiver": {}<br/>}</pre> | no |
 
 ## Outputs
 

--- a/modules/regional-go-reconciler/main.tf
+++ b/modules/regional-go-reconciler/main.tf
@@ -32,6 +32,7 @@ module "workqueue" {
   labels                = var.labels
 
   multi_regional_location = var.multi_regional_location
+  cpu_idle                = var.workqueue_cpu_idle
 
   depends_on = [module.reconciler]
 }

--- a/modules/regional-go-reconciler/variables.tf
+++ b/modules/regional-go-reconciler/variables.tf
@@ -244,3 +244,12 @@ variable "notification_channels" {
   type        = list(string)
   default     = []
 }
+
+variable "workqueue_cpu_idle" {
+  description = "Set to false for a region in order to use instance-based billing for workqueue services (dispatcher and receiver). Defaults to true. To control reconciler cpu_idle, use the 'regional-cpu-idle' field in the 'containers' variable."
+  type        = map(map(bool))
+  default = {
+    "dispatcher" = {}
+    "receiver"   = {}
+  }
+}

--- a/modules/workqueue/README.md
+++ b/modules/workqueue/README.md
@@ -193,6 +193,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_concurrent-work"></a> [concurrent-work](#input\_concurrent-work) | The amount of concurrent work to dispatch at a given time. | `number` | n/a | yes |
+| <a name="input_cpu_idle"></a> [cpu\_idle](#input\_cpu\_idle) | Set to false for a region in order to use instance-based billing. Defaults to true. | `map(map(bool))` | <pre>{<br/>  "dispatcher": {},<br/>  "receiver": {}<br/>}</pre> | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable delete protection for the service. | `bool` | `true` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the workqueue resources. | `map(string)` | `{}` | no |
 | <a name="input_max-retry"></a> [max-retry](#input\_max-retry) | The maximum number of retry attempts before a task is moved to the dead letter queue. Set this to 0 to have unlimited retries. | `number` | `100` | no |

--- a/modules/workqueue/dispatcher.tf
+++ b/modules/workqueue/dispatcher.tf
@@ -79,6 +79,7 @@ module "dispatcher-service" {
           value = { for k, v in module.dispatcher-calls-target : k => v.uri }
         },
       ]
+      regional-cpu-idle = lookup(var.cpu_idle, "dispatcher", {})
     }
   }
 

--- a/modules/workqueue/main.tf
+++ b/modules/workqueue/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 resource "random_string" "bucket_suffix" {
-  length  = 6  // Same length as "global"
+  length  = 6 // Same length as "global"
   special = false
   upper   = false
   numeric = true

--- a/modules/workqueue/receiver.tf
+++ b/modules/workqueue/receiver.tf
@@ -59,6 +59,7 @@ module "receiver-service" {
           }
         },
       ]
+      regional-cpu-idle = lookup(var.cpu_idle, "receiver", {})
     }
   }
 

--- a/modules/workqueue/variables.tf
+++ b/modules/workqueue/variables.tf
@@ -81,3 +81,12 @@ variable "multi_regional_location" {
     error_message = "multi_regional_location must be one of 'US', 'EU', or 'ASIA'."
   }
 }
+
+variable "cpu_idle" {
+  description = "Set to false for a region in order to use instance-based billing. Defaults to true."
+  type        = map(map(bool))
+  default = {
+    "dispatcher" = {}
+    "receiver"   = {}
+  }
+}


### PR DESCRIPTION
`cpu_idle = false` means instance-based billing, which is cheaper for us for some services in some regions.

- Part of https://github.com/chainguard-dev/internal-dev/issues/20110
- Related to https://github.com/chainguard-dev/mono/pull/27115

I've tested this in my dev environment.