### PR TITLE
Fix non-intuitive `RequeueAfter(0)` behavior.

### DIFF
--- a/pkg/workqueue/error.go
+++ b/pkg/workqueue/error.go
@@ -62,8 +62,15 @@ func (e *requeueError) Error() string {
 }
 
 // RequeueAfter returns an error that indicates the work item should be requeued
-// after the specified delay.
+// after the specified delay. If the delay is less than 1 second, it returns
+// a regular error that triggers an immediate retry instead of a delayed requeue.
 func RequeueAfter(delay time.Duration) error {
+	// For delays less than 1 second, return a regular error to trigger
+	// an immediate retry. This avoids the issue where RequeueAfter(0)
+	// gets treated as "no requeue specified".
+	if delay < 1*time.Second {
+		return errors.New("immediate retry requested")
+	}
 	return &requeueError{delay: delay}
 }
 

--- a/pkg/workqueue/error_test.go
+++ b/pkg/workqueue/error_test.go
@@ -16,24 +16,32 @@ func TestRequeueAfter(t *testing.T) {
 	tests := []struct {
 		name      string
 		delay     time.Duration
-		wantDelay time.Duration
-	}{
-		{
-			name:      "5 second delay",
-			delay:     5 * time.Second,
-			wantDelay: 5 * time.Second,
-		},
-		{
-			name:      "1 minute delay",
-			delay:     time.Minute,
-			wantDelay: time.Minute,
-		},
-		{
-			name:      "zero delay",
-			delay:     0,
-			wantDelay: 0,
-		},
-	}
+		wantDelay time.Duration // 0 means immediate retry, >0 means requeue with that delay
+	}{{
+		name:      "zero delay triggers immediate retry",
+		delay:     0,
+		wantDelay: 0,
+	}, {
+		name:      "500ms delay triggers immediate retry",
+		delay:     500 * time.Millisecond,
+		wantDelay: 0,
+	}, {
+		name:      "999ms delay triggers immediate retry",
+		delay:     999 * time.Millisecond,
+		wantDelay: 0,
+	}, {
+		name:      "1 second delay uses requeue",
+		delay:     1 * time.Second,
+		wantDelay: 1 * time.Second,
+	}, {
+		name:      "5 second delay uses requeue",
+		delay:     5 * time.Second,
+		wantDelay: 5 * time.Second,
+	}, {
+		name:      "1 minute delay uses requeue",
+		delay:     time.Minute,
+		wantDelay: time.Minute,
+	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,12 +50,25 @@ func TestRequeueAfter(t *testing.T) {
 				t.Fatal("Expected non-nil error")
 			}
 
-			gotDelay, ok := GetRequeueDelay(err)
-			if !ok {
-				t.Fatal("GetRequeueDelay returned false")
+			gotDelay, gotRequeue := GetRequeueDelay(err)
+			wantRequeue := tt.wantDelay > 0
+
+			if gotRequeue != wantRequeue {
+				t.Errorf("requeue type: got = %v, wanted = %v", gotRequeue, wantRequeue)
 			}
 			if gotDelay != tt.wantDelay {
-				t.Errorf("Got delay %v, want %v", gotDelay, tt.wantDelay)
+				t.Errorf("delay: got = %v, wanted = %v", gotDelay, tt.wantDelay)
+			}
+
+			// Check error message
+			if wantRequeue {
+				if got := err.Error(); got != "requeue requested" {
+					t.Errorf("error message: got = %q, wanted = %q", got, "requeue requested")
+				}
+			} else {
+				if got := err.Error(); got != "immediate retry requested" {
+					t.Errorf("error message: got = %q, wanted = %q", got, "immediate retry requested")
+				}
 			}
 		})
 	}
@@ -59,53 +80,56 @@ func TestGetRequeueDelay(t *testing.T) {
 		err       error
 		wantDelay time.Duration
 		wantOk    bool
-	}{
-		{
-			name:      "requeue error",
-			err:       RequeueAfter(10 * time.Second),
-			wantDelay: 10 * time.Second,
-			wantOk:    true,
-		},
-		{
-			name:      "regular error",
-			err:       errors.New("some error"),
-			wantDelay: 0,
-			wantOk:    false,
-		},
-		{
-			name:      "nil error",
-			err:       nil,
-			wantDelay: 0,
-			wantOk:    false,
-		},
-		{
-			name:      "wrapped requeue error",
-			err:       fmt.Errorf("operation failed: %w", RequeueAfter(15*time.Second)),
-			wantDelay: 15 * time.Second,
-			wantOk:    true,
-		},
-		{
-			name:      "double wrapped requeue error",
-			err:       fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", RequeueAfter(20*time.Second))),
-			wantDelay: 20 * time.Second,
-			wantOk:    true,
-		},
-		{
-			name:      "wrapped regular error",
-			err:       fmt.Errorf("wrapped: %w", errors.New("some error")),
-			wantDelay: 0,
-			wantOk:    false,
-		},
-	}
+	}{{
+		name:      "requeue error with 10s delay",
+		err:       RequeueAfter(10 * time.Second),
+		wantDelay: 10 * time.Second,
+		wantOk:    true,
+	}, {
+		name:      "immediate retry from zero delay",
+		err:       RequeueAfter(0),
+		wantDelay: 0,
+		wantOk:    false, // Should be a regular error, not a requeue error
+	}, {
+		name:      "immediate retry from 500ms delay",
+		err:       RequeueAfter(500 * time.Millisecond),
+		wantDelay: 0,
+		wantOk:    false, // Should be a regular error, not a requeue error
+	}, {
+		name:      "regular error",
+		err:       errors.New("some error"),
+		wantDelay: 0,
+		wantOk:    false,
+	}, {
+		name:      "nil error",
+		err:       nil,
+		wantDelay: 0,
+		wantOk:    false,
+	}, {
+		name:      "wrapped requeue error",
+		err:       fmt.Errorf("operation failed: %w", RequeueAfter(15*time.Second)),
+		wantDelay: 15 * time.Second,
+		wantOk:    true,
+	}, {
+		name:      "double wrapped requeue error",
+		err:       fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", RequeueAfter(20*time.Second))),
+		wantDelay: 20 * time.Second,
+		wantOk:    true,
+	}, {
+		name:      "wrapped regular error",
+		err:       fmt.Errorf("wrapped: %w", errors.New("some error")),
+		wantDelay: 0,
+		wantOk:    false,
+	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotDelay, gotOk := GetRequeueDelay(tt.err)
 			if gotOk != tt.wantOk {
-				t.Errorf("Got ok=%v, want %v", gotOk, tt.wantOk)
+				t.Errorf("ok: got = %v, wanted = %v", gotOk, tt.wantOk)
 			}
 			if gotDelay != tt.wantDelay {
-				t.Errorf("Got delay %v, want %v", gotDelay, tt.wantDelay)
+				t.Errorf("delay: got = %v, wanted = %v", gotDelay, tt.wantDelay)
 			}
 		})
 	}


### PR DESCRIPTION
Today the way we handle `RequeueAfter(0)` is to return a wrapped error with the value set to 0.

The way this is turned into a response in Process methods is to extract it and populate the value.

The problem is that populating a value of 0 is indistinguishable from not setting it, so things do not get requeued.

Instead, we are changing RequeueAfter with any value less than 1s (we use second-resolution for delays) will return a normal error to trigger an immediate retry.