### PR TITLE
reconciler: Add HTTP section to dashboard

### DIFF
--- a/modules/dashboard/reconciler/README.md
+++ b/modules/dashboard/reconciler/README.md
@@ -99,6 +99,7 @@ No providers.
 | <a name="module_errgrp"></a> [errgrp](#module\_errgrp) | ../sections/errgrp | n/a |
 | <a name="module_github"></a> [github](#module\_github) | ../sections/github | n/a |
 | <a name="module_grpc"></a> [grpc](#module\_grpc) | ../sections/grpc | n/a |
+| <a name="module_http"></a> [http](#module\_http) | ../sections/http | n/a |
 | <a name="module_layout"></a> [layout](#module\_layout) | ../sections/layout | n/a |
 | <a name="module_reconciler-logs"></a> [reconciler-logs](#module\_reconciler-logs) | ../sections/logs | n/a |
 | <a name="module_resources"></a> [resources](#module\_resources) | ../sections/resources | n/a |

--- a/modules/dashboard/reconciler/dashboard.tf
+++ b/modules/dashboard/reconciler/dashboard.tf
@@ -36,6 +36,13 @@ module "reconciler-logs" {
   cloudrun_type = "service"
 }
 
+module "http" {
+  source       = "../sections/http"
+  title        = "HTTP"
+  filter       = []
+  service_name = local.service_name
+}
+
 module "grpc" {
   source       = "../sections/grpc"
   title        = "GRPC"
@@ -76,6 +83,7 @@ module "layout" {
       module.workqueue-state.section,
       module.errgrp.section,
       module.reconciler-logs.section,
+      module.http.section,
       module.grpc.section,
     ],
     var.sections.github ? [module.github.section] : [],


### PR DESCRIPTION
Reconcilers don't only do gRPC based traffic, but they'll also use HTTP clients etc. This shows them in the dashboard.