### PR TITLE
reconciler: Fix time-to-completion and attempts-at-completion widgets

### DIFF
--- a/modules/dashboard/sections/workqueue/README.md
+++ b/modules/dashboard/sections/workqueue/README.md
@@ -54,13 +54,13 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_attempts-at-completion"></a> [attempts-at-completion](#module\_attempts-at-completion) | ../../widgets/xy-promql | n/a |
+| <a name="module_attempts-at-completion"></a> [attempts-at-completion](#module\_attempts-at-completion) | ../../widgets/xy | n/a |
 | <a name="module_collapsible"></a> [collapsible](#module\_collapsible) | ../collapsible | n/a |
 | <a name="module_dead-letter-queue"></a> [dead-letter-queue](#module\_dead-letter-queue) | ../../widgets/xy | n/a |
 | <a name="module_max-attempts"></a> [max-attempts](#module\_max-attempts) | ../../widgets/xy | n/a |
 | <a name="module_percent-deduped"></a> [percent-deduped](#module\_percent-deduped) | ../../widgets/xy-ratio | n/a |
 | <a name="module_process-latency"></a> [process-latency](#module\_process-latency) | ../../widgets/latency | n/a |
-| <a name="module_time-to-completion"></a> [time-to-completion](#module\_time-to-completion) | ../../widgets/xy-promql | n/a |
+| <a name="module_time-to-completion"></a> [time-to-completion](#module\_time-to-completion) | ../../widgets/xy | n/a |
 | <a name="module_wait-latency"></a> [wait-latency](#module\_wait-latency) | ../../widgets/latency | n/a |
 | <a name="module_width"></a> [width](#module\_width) | ../width | n/a |
 | <a name="module_work-added"></a> [work-added](#module\_work-added) | ../../widgets/xy | n/a |


### PR DESCRIPTION
The attempts-at-completion widget is currently not aggregating across the instances so it shows per instance stats, which is noisy. The time-to-completion query plainly doesn't work and errors out currently.

This changes both to not use promQL and instead use builder-based queries to make them easier to deal with.