### PR TITLE
add a module to concat two strings, subject to a given maximum length

### DIFF
--- a/modules/limited-concat/README.md
+++ b/modules/limited-concat/README.md
@@ -1,0 +1,59 @@
+# `limited-concat`
+
+This module takes two strings, `prefix` and `suffix`, and returns the concatenation
+of the two, up to a given `limit` length. If the concatenation is longer than `limit`,
+the `prefix` is shortened so that
+`length(output.result) == var.limit`
+
+```hcl
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+module "limited-name" {
+  source = "chainguard-dev/common/infra//modules/limited-concat"
+
+  prefix = "foo-bar-baz"
+  suffix = "-${random_string.suffix.result}"
+  limit  = 12
+}
+
+output "limited-name" {
+  value = module.limited-name.result
+}
+# Output: foo-bar-wxyz
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_limit"></a> [limit](#input\_limit) | Maximum length of the resulting concatenation. | `number` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | First part of the result, will be shortened if length(prefix)+length(suffix) > limit. | `string` | n/a | yes |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | Second part of the result, included in whole. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_result"></a> [result](#output\_result) | The concatenation of prefix and suffix, with limit applied. |
+<!-- END_TF_DOCS -->

--- a/modules/limited-concat/main.tf
+++ b/modules/limited-concat/main.tf
@@ -1,0 +1,9 @@
+locals {
+  # NB: substr returns the entire string if length is greater than the length of the string.
+  prefix = substr(var.prefix, 0, (var.limit - length(var.suffix)))
+}
+
+output "result" {
+  description = "The concatenation of prefix and suffix, with limit applied."
+  value = "${local.prefix}${var.suffix}"
+}

--- a/modules/limited-concat/variables.tf
+++ b/modules/limited-concat/variables.tf
@@ -1,0 +1,19 @@
+variable "prefix" {
+  description = "First part of the result, will be shortened if length(prefix)+length(suffix) > limit."
+  type = string
+}
+
+variable "suffix" {
+  description = "Second part of the result, included in whole."
+  type = string
+}
+
+variable "limit" {
+  description = "Maximum length of the resulting concatenation."
+  type = number
+
+  validation {
+    condition = var.limit >= length(var.suffix)
+    error_message = "limit cannot be less than the length of suffix."
+  }
+}


### PR DESCRIPTION
There are a few resources that have constraints on the length of their names. We currently apply the same name to a bunch of subresources within modules, and if one violates a maximum length requirement the entire module fails. This module intends to allow us to only shorten names when necessary, and otherwise continue using the caller provided names as is.