### PR TITLE
Check whether var.slo is null before accessing enabled

### DIFF
--- a/modules/regional-service/main.tf
+++ b/modules/regional-service/main.tf
@@ -370,7 +370,7 @@ resource "google_cloud_run_v2_service_iam_member" "public-services-are-unauthent
 }
 
 module "slo" {
-  count = var.slo.enable ? 1 : 0
+  count = (var.slo != null && var.slo.enable) ? 1 : 0
 
   source = "../slo"
 


### PR DESCRIPTION
We're seeing errors like this since `var.slo` defaults to `null`:
```
Error: Attempt to get attribute from null value

  on .terraform/modules/.../modules/regional-service/main.tf line 373, in module "slo":
 373:   count = var.slo.enable ? 1 : 0
    ├────────────────
    │ var.slo is null

```

This PR checks whether `var.slo` is `null` before accessing the value of `enabled`.