### PR TITLE
fix when both team and squad are empty

### DIFF
--- a/modules/alerting/main.tf
+++ b/modules/alerting/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 locals {
-  effective_team                 = coalesce(var.team, var.squad, "")
+  effective_team                 = coalesce(var.team, var.squad, "unknown")
   squad_log_filter               = local.effective_team == "" ? "" : "labels.squad=\"${local.effective_team}\""
   squad_proto_log_filter         = local.effective_team == "" ? "" : "protoPayload.response.metadata.labels.squad=\"${local.effective_team}\""
   name                           = local.effective_team == "" ? "global" : local.effective_team


### PR DESCRIPTION
failure in https://github.com/chainguard-dev/mono/actions/runs/18555696390/job/52893418624?pr=27978

```
 Error: Error in function call

on .terraform/modules/global-alert/modules/alerting/main.tf line 16, in locals:
16:   effective_team                 = coalesce(var.team, var.squad, "")
  ├────────────────
  │ while calling coalesce(vals...)
  │ var.squad is ""
  │ var.team is ""
```

Claude help me to explain the issue

The coalesce function in Terraform returns the first non-null, non-empty argument from the list of arguments provided.

How coalesce works:

- coalesce(val1, val2, val3, ...) evaluates each argument in order
- It returns the first argument that is NOT null or empty
- If ALL arguments are null or empty, it fails with an error

Why it was failing in your case:

```
effective_team = coalesce(var.team, var.squad, "")
```

When both var.team and var.squad are empty strings (""), coalesce receives:

1. var.team = "" (empty, skip)
2. var.squad = "" (empty, skip)
3. "" (empty, skip)
Since all three arguments are empty, coalesce has nothing to return and throws an error.

The confusion:

You might expect coalesce to return the empty string "" at the end, but Terraform's coalesce function specifically rejects empty strings as valid values. It only accepts "truthy" non-empty values.

The fix:

The ternary expression `var.team != "" ? var.team : var.squad` doesn't have this limitation:

- It simply checks if var.team is not empty
- If true, returns var.team
- If false, returns var.squad (even if it's empty)
- This allows empty strings as valid results
- This is a common gotcha with Terraform's `coalesce` function!