### PR TITLE
Make pullrequesturl lowest-common-denominator.

### DIFF
--- a/modules/github-events/internal/trampoline/server.go
+++ b/modules/github-events/internal/trampoline/server.go
@@ -295,15 +295,19 @@ func extractPullRequestURL(eventType string, info PayloadInfo) string {
 		if info.Issue.PullRequestInfo != nil && info.Issue.Number > 0 {
 			prNumber = info.Issue.Number
 		}
-	case "check_run":
-		if len(info.CheckRun.PullRequests) > 0 {
-			prNumber = info.CheckRun.PullRequests[0].Number
-		}
-	case "check_suite":
-		if len(info.CheckSuite.PullRequests) > 0 {
-			prNumber = info.CheckSuite.PullRequests[0].Number
-		}
 	}
+	// TODO(mattmoor): Github doesn't reliably set this field, e.g. it is not
+	// populated for check runs on PRs from forks, so this is an unreliable
+	// source of this metadata.  To avoid folks falling into the trap of relying
+	// on this, disable decorating this metadata for check runs.
+	// case "check_run":
+	// 	if len(info.CheckRun.PullRequests) > 0 {
+	// 		prNumber = info.CheckRun.PullRequests[0].Number
+	// 	}
+	// case "check_suite":
+	// 	if len(info.CheckSuite.PullRequests) > 0 {
+	// 		prNumber = info.CheckSuite.PullRequests[0].Number
+	// 	}
 
 	if prNumber > 0 {
 		return fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, prNumber)

--- a/modules/github-events/internal/trampoline/server_test.go
+++ b/modules/github-events/internal/trampoline/server_test.go
@@ -824,52 +824,6 @@ func TestPullRequestURLExtensionMultipleEventTypes(t *testing.T) {
 			expectedURL: "https://github.com/user/project/pull/789",
 		},
 		{
-			name:      "check_run event with PR",
-			eventType: "check_run",
-			payload: map[string]interface{}{
-				"action": "completed",
-				"check_run": map[string]interface{}{
-					"id": 999,
-					"pull_requests": []interface{}{
-						map[string]interface{}{
-							"number": 111,
-						},
-					},
-				},
-				"repository": map[string]interface{}{
-					"full_name": "test/repo",
-					"owner": map[string]interface{}{
-						"login": "test",
-					},
-					"name": "repo",
-				},
-			},
-			expectedURL: "https://github.com/test/repo/pull/111",
-		},
-		{
-			name:      "check_suite event with PR",
-			eventType: "check_suite",
-			payload: map[string]interface{}{
-				"action": "completed",
-				"check_suite": map[string]interface{}{
-					"id": 888,
-					"pull_requests": []interface{}{
-						map[string]interface{}{
-							"number": 222,
-						},
-					},
-				},
-				"repository": map[string]interface{}{
-					"full_name": "corp/app",
-					"owner": map[string]interface{}{
-						"login": "corp",
-					},
-					"name": "app",
-				},
-			},
-			expectedURL: "https://github.com/corp/app/pull/222",
-		},
-		{
 			name:      "check_run event without PR",
 			eventType: "check_run",
 			payload: map[string]interface{}{


### PR DESCRIPTION
We only get this for branches on the upstream, but not from forks.

Unless/Until this information is populated, this is an unreliable trigger for reconciliation.

It is also notable that most reconcilers don't actually react to check run completions, and where we do we want to handle forks, so we have had to work around this anyways.

So including this creates both unnecessary churn in the reconcilers while not being sufficient for the cases that actually care.